### PR TITLE
chore: added GitHub issue and pull request templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -20,7 +20,7 @@ A clear and concise description of what is the bug.
 
 ### Related to
 
-- [ ] Components
+- [ ] Unistyles core
 - [ ] Demo
 - [ ] Docs
 - [ ] Typings

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,84 @@
+---
+name: Bug Report
+about: Create a report to help us improve
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+<!--
+NOTE: please submit only bug reports here, any new questions or feature requests should be submitted in Discussions:
+https://github.com/jpudysz/react-native-unistyles/discussions
+ -->
+
+## Description
+
+<!--
+A clear and concise description of what is the bug.
+-->
+
+### Related to
+
+- [ ] Components
+- [ ] Demo
+- [ ] Docs
+- [ ] Typings
+
+### Steps to reproduce
+
+<!--
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+-->
+
+#### Expected behavior
+
+<!--
+A clear and concise description of what you expected to happen.
+-->
+
+#### Actual behavior
+
+<!--
+A clear and concise description of what actually happens.
+-->
+
+## More Info
+
+### Code snippet
+
+<!--
+A code snippet that reproduce the issue. 
+-->
+
+```
+
+
+```
+
+### Screenshots/Video
+
+<!--
+If applicable, add screenshots or a video to help explain your problem.
+-->
+
+### Environment
+
+<!--
+Fill in your react-native-unistyles and React Native versions below.
+
+List other libraries if relevant.
+-->
+
+- React Native version:
+- react-native-unistyles version:
+
+### Affected platforms
+
+- [ ] Android
+- [ ] iOS
+- [ ] Web

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Question
+    url: https://github.com/jpudysz/react-native-unistyles/discussions/categories/q-a
+    about: Please ask and answer questions here.
+  - name: Feature Request
+    url: https://github.com/jpudysz/react-native-unistyles/discussions/categories/ideas
+    about: Please submit feature requests / suggestions here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,9 @@
+<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->
+
+## Summary
+
+<!-- Explain the motivation for this PR. Include "Fixes #<number>" if applicable. -->
+
+## Test plan
+
+<!-- Provide a minimal but complete code snippet that can be used to test out this change along with instructions how to run it and a description of the expected behavior. -->


### PR DESCRIPTION
@jpudysz I've added these to better organize/categorize issues and give devs a hint to use Discussions for feature requests and discussions. 

Please rename `Ideas` topic on Discussions `Feature Requests` for better naming convention. There's no way to change the link `https://github.com/jpudysz/react-native-unistyles/discussions/categories/ideas` to `/feature-requests`, just fyi.

Let me know if templates needs to be changed