### PR TITLE
Simplify MediaQueries type

### DIFF
--- a/src/types/mediaQueries.ts
+++ b/src/types/mediaQueries.ts
@@ -1,69 +1,10 @@
+type Optional<TOptional extends string> = TOptional | ''
+type Separator = ',' | ', '
+type MediaQuery = `[${Separator}${bigint}]` | `[${bigint}${Optional<`${Separator}${bigint}`>}]`
+type WidthMediaQuery = `:w${MediaQuery}`
+type HeightMediaQuery = `:h${MediaQuery}`
+
 // this is super weird, but number passes empty string and bigint does not
 export type MediaQueries =
-// For :w
-`:w[${bigint}]` |
-`:w[,${bigint}]` |
-`:w[, ${bigint}]` |
-`:w[${bigint},${bigint}]` |
-`:w[${bigint}, ${bigint}]` |
-
-// For :h
-`:h[${bigint}]` |
-`:h[,${bigint}]` |
-`:h[, ${bigint}]` |
-`:h[${bigint},${bigint}]` |
-`:h[${bigint}, ${bigint}]` |
-
-// Combinations of :w and :h
-`:w[${bigint}]:h[${bigint}]` |
-`:w[${bigint},${bigint}]:h[${bigint}]` |
-`:w[${bigint}, ${bigint}]:h[${bigint}]` |
-`:w[${bigint}]:h[${bigint},${bigint}]` |
-`:w[${bigint}]:h[${bigint}, ${bigint}]` |
-`:w[${bigint},${bigint}]:h[${bigint},${bigint}]` |
-`:w[${bigint}, ${bigint}]:h[${bigint},${bigint}]` |
-`:w[${bigint},${bigint}]:h[${bigint}, ${bigint}]` |
-`:w[${bigint}, ${bigint}]:h[${bigint}, ${bigint}]` |
-`:w[,${bigint}]:h[,${bigint}]` |
-`:w[, ${bigint}]:h[,${bigint}]` |
-`:w[,${bigint}]:h[, ${bigint}]` |
-`:w[, ${bigint}]:h[, ${bigint}]` |
-`:w[,${bigint}]:h[${bigint}]` |
-`:w[, ${bigint}]:h[${bigint}]` |
-`:w[${bigint}]:h[,${bigint}]` |
-`:w[${bigint}]:h[, ${bigint}]` |
-`:w[,${bigint}]:h[${bigint},${bigint}]` |
-`:w[, ${bigint}]:h[${bigint},${bigint}]` |
-`:w[,${bigint}]:h[${bigint}, ${bigint}]` |
-`:w[, ${bigint}]:h[${bigint}, ${bigint}]` |
-`:w[${bigint},${bigint}]:h[,${bigint}]` |
-`:w[${bigint}, ${bigint}]:h[,${bigint}]` |
-`:w[${bigint},${bigint}]:h[, ${bigint}]` |
-`:w[${bigint}, ${bigint}]:h[, ${bigint}]` |
-
-// Combinations of :h and :w
-`:h[${bigint}]:w[${bigint}]` |
-`:h[${bigint},${bigint}]:w[${bigint}]` |
-`:h[${bigint}, ${bigint}]:w[${bigint}]` |
-`:h[${bigint}]:w[${bigint},${bigint}]` |
-`:h[${bigint}]:w[${bigint}, ${bigint}]` |
-`:h[${bigint},${bigint}]:w[${bigint},${bigint}]` |
-`:h[${bigint}, ${bigint}]:w[${bigint},${bigint}]` |
-`:h[${bigint},${bigint}]:w[${bigint}, ${bigint}]` |
-`:h[${bigint}, ${bigint}]:w[${bigint}, ${bigint}]` |
-`:h[,${bigint}]:w[,${bigint}]` |
-`:h[, ${bigint}]:w[,${bigint}]` |
-`:h[,${bigint}]:w[, ${bigint}]` |
-`:h[, ${bigint}]:w[, ${bigint}]` |
-`:h[,${bigint}]:w[${bigint}]` |
-`:h[, ${bigint}]:w[${bigint}]` |
-`:h[${bigint}]:w[,${bigint}]` |
-`:h[${bigint}]:w[, ${bigint}]` |
-`:h[,${bigint}]:w[${bigint},${bigint}]` |
-`:h[, ${bigint}]:w[${bigint},${bigint}]` |
-`:h[,${bigint}]:w[${bigint}, ${bigint}]` |
-`:h[, ${bigint}]:w[${bigint}, ${bigint}]` |
-`:h[${bigint},${bigint}]:w[,${bigint}]` |
-`:h[${bigint}, ${bigint}]:w[,${bigint}]` |
-`:h[${bigint},${bigint}]:w[, ${bigint}]` |
-`:h[${bigint}, ${bigint}]:w[, ${bigint}]`
+    | `${WidthMediaQuery}${Optional<HeightMediaQuery>}`
+    | `${HeightMediaQuery}${Optional<WidthMediaQuery>}`


### PR DESCRIPTION
## Summary

Types in lib/types/mediaQueries.ts aren't very optimal for future changes. Every type is written by hand. We can use [template literal types](https://www.typescriptlang.org/docs/handbook/2/template-literal-types.html) to fix that issue.

![image](https://github.com/jpudysz/react-native-unistyles/assets/48803618/cab7f179-649d-4d03-b052-565ee8ddd3ae)
