### PR TITLE
Normalize all colors that React Native supports

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   "devDependencies": {
     "@commitlint/config-conventional": "17.8.0",
     "@react-native/eslint-config": "0.74.0",
+    "@react-native/normalize-colors": "0.74.1",
     "@release-it/conventional-changelog": "5.1.1",
     "@testing-library/react-hooks": "8.0.1",
     "@types/jest": "29.5.5",
@@ -75,6 +76,7 @@
     "typescript": "5.2.2"
   },
   "peerDependencies": {
+    "@react-native/normalize-colors": "*",
     "react": "*",
     "react-native": "*",
     "react-native-web": "*"

--- a/src/__tests__/normalizer.spec.ts
+++ b/src/__tests__/normalizer.spec.ts
@@ -68,16 +68,26 @@ describe('Normalizer', () => {
                         height: -10
                     },
                     shadowOpacity: 0.5
+                },
+                {
+                    shadowRadius: 3,
+                    shadowColor: 'blue',
+                    shadowOffset: {
+                        width: 0,
+                        height: -10
+                    },
+                    shadowOpacity: 0.5
                 }
             ]
             const results: Array<string> = [
                 '3px 2px 3px rgba(0,0,0,0.4)',
-                '0 0 1px rgba(171,202,188,1)',
+                '0 0 1px #abcabc',
                 '0 1px 0 rgba(127,17,224,0.3)',
                 '-4px -3px 3px rgba(255,87,51,0.5)',
                 '0 0 0 rgba(0,0,0,0)',
                 '50px 50px 20px orange',
-                '0 -10px 3px rgba(255,87,51,0.8)'
+                '0 -10px 3px rgba(255,87,51,0.4)',
+                '0 -10px 3px rgba(0,0,255,0.5)'
             ]
 
             styles.forEach((style, index) => {
@@ -131,11 +141,11 @@ describe('Normalizer', () => {
                 }
             ]
             const results: Array<string> = [
-                '4px 5px 2px rgba(255,255,255,1)',
-                '3px 4px 5px rgba(0,0,0,1)',
-                '-1px -1px 0 rgba(255,87,51,1)',
+                '4px 5px 2px #fff',
+                '3px 4px 5px #000000',
+                '-1px -1px 0 #FF5733',
                 '0 0 0 red',
-                '-5px -5px 0 rgba(255,87,51,0.8)'
+                '-5px -5px 0 #FF5733CC'
             ]
 
             styles.forEach((style, index) => {
@@ -237,8 +247,15 @@ describe('Normalizer', () => {
     })
 
     describe('normalizeColor', () => {
-        it('should not normalize string colors', () => {
+        it('should not normalize string colors when no opacity is defined', () => {
             const values: Array<string> = [
+                'red',
+                'orange',
+                'pink',
+                'purple',
+                'black'
+            ]
+            const results: Array<string> = [
                 'red',
                 'orange',
                 'pink',
@@ -247,7 +264,28 @@ describe('Normalizer', () => {
             ]
 
             values.forEach((value, index) => {
-                expect(normalizeColor(value)).toEqual(values[index])
+                expect(normalizeColor(value)).toEqual(results[index])
+            })
+        })
+
+        it('should normalize string colors when opacity is defined', () => {
+            const values: Array<string> = [
+                'red',
+                'orange',
+                'pink',
+                'purple',
+                'black'
+            ]
+            const results: Array<string> = [
+                'rgba(255,0,0,0.5)',
+                'rgba(255,165,0,0.5)',
+                'rgba(255,192,203,0.5)',
+                'rgba(128,0,128,0.5)',
+                'rgba(0,0,0,0.5)'
+            ]
+
+            values.forEach((value, index) => {
+                expect(normalizeColor(value, 0.5)).toEqual(results[index])
             })
         })
 
@@ -265,20 +303,20 @@ describe('Normalizer', () => {
                 '#456'
             ]
             const results: Array<string> = [
-                'rgba(255,0,0,1)',
-                'rgba(0,255,0,1)',
-                'rgba(0,0,255,1)',
-                'rgba(255,255,0,1)',
-                'rgba(255,0,255,1)',
-                'rgba(0,255,255,1)',
-                'rgba(255,255,255,1)',
-                'rgba(170,187,204,1)',
-                'rgba(17,34,51,1)',
-                'rgba(68,85,102,1)'
+                'rgba(255,0,0,0.2)',
+                'rgba(0,255,0,0.2)',
+                'rgba(0,0,255,0.2)',
+                'rgba(255,255,0,0.2)',
+                'rgba(255,0,255,0.2)',
+                'rgba(0,255,255,0.2)',
+                'rgba(255,255,255,0.2)',
+                'rgba(170,187,204,0.2)',
+                'rgba(17,34,51,0.2)',
+                'rgba(68,85,102,0.2)'
             ]
 
             values.forEach((value, index) => {
-                expect(normalizeColor(value)).toEqual(results[index])
+                expect(normalizeColor(value, 0.2)).toEqual(results[index])
             })
         })
 
@@ -296,20 +334,20 @@ describe('Normalizer', () => {
                 '#445566'
             ]
             const results: Array<string> = [
-                'rgba(255,0,0,1)',
-                'rgba(0,255,0,1)',
-                'rgba(0,0,255,1)',
-                'rgba(255,255,0,1)',
-                'rgba(255,0,255,1)',
-                'rgba(0,255,255,1)',
-                'rgba(255,255,255,1)',
-                'rgba(170,187,204,1)',
-                'rgba(17,34,51,1)',
-                'rgba(68,85,102,1)'
+                'rgba(255,0,0,0.99)',
+                'rgba(0,255,0,0.99)',
+                'rgba(0,0,255,0.99)',
+                'rgba(255,255,0,0.99)',
+                'rgba(255,0,255,0.99)',
+                'rgba(0,255,255,0.99)',
+                'rgba(255,255,255,0.99)',
+                'rgba(170,187,204,0.99)',
+                'rgba(17,34,51,0.99)',
+                'rgba(68,85,102,0.99)'
             ]
 
             values.forEach((value, index) => {
-                expect(normalizeColor(value)).toEqual(results[index])
+                expect(normalizeColor(value, 0.99)).toEqual(results[index])
             })
         })
 
@@ -327,20 +365,20 @@ describe('Normalizer', () => {
                 '#44556677'
             ]
             const results: Array<string> = [
-                'rgba(255,0,0,1)',
-                'rgba(0,255,0,1)',
-                'rgba(0,0,255,1)',
-                'rgba(255,255,0,1)',
-                'rgba(255,0,255,1)',
-                'rgba(0,255,255,1)',
-                'rgba(255,255,255,1)',
-                'rgba(170,187,204,0.8666666666666667)',
-                'rgba(17,34,51,0.26666666666666666)',
-                'rgba(68,85,102,0.4666666666666667)'
+                'rgba(255,0,0,0.1)',
+                'rgba(0,255,0,0.1)',
+                'rgba(0,0,255,0.1)',
+                'rgba(255,255,0,0.1)',
+                'rgba(255,0,255,0.1)',
+                'rgba(0,255,255,0.1)',
+                'rgba(255,255,255,0.1)',
+                'rgba(170,187,204,0.08666666666666667)',
+                'rgba(17,34,51,0.02666666666666667)',
+                'rgba(68,85,102,0.04666666666666667)'
             ]
 
             values.forEach((value, index) => {
-                expect(normalizeColor(value)).toEqual(results[index])
+                expect(normalizeColor(value, 0.1)).toEqual(results[index])
             })
         })
     })
@@ -398,11 +436,11 @@ describe('Normalizer', () => {
                     width: 0,
                     height: 0
                 },
-                shadowOpacity: 1,
+                shadowOpacity: 0.5,
                 shadowRadius: 5
             }
             expect(normalizeStylesWeb(styles)).toEqual({
-                boxShadow: '0 0 5px rgba(0,0,0,1)',
+                boxShadow: '0 0 5px rgba(0,0,0,0.5)',
                 shadowColor: undefined,
                 shadowOffset: undefined,
                 shadowOpacity: undefined,
@@ -420,7 +458,7 @@ describe('Normalizer', () => {
                 textShadowRadius: 12
             }
             expect(normalizeStylesWeb(styles)).toEqual({
-                textShadow: '-5px 0 12px rgba(255,255,255,1)',
+                textShadow: '-5px 0 12px #fff',
                 textShadowColor: undefined,
                 textShadowOffset: undefined,
                 textShadowRadius: undefined

--- a/src/utils/module.d.ts
+++ b/src/utils/module.d.ts
@@ -1,0 +1,3 @@
+declare module '@react-native/normalize-colors' {
+    export default function normalizeColor(color: string): number | null
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3917,7 +3917,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@react-native/normalize-colors@npm:*":
+"@react-native/normalize-colors@npm:*, @react-native/normalize-colors@npm:0.74.1":
   version: 0.74.1
   resolution: "@react-native/normalize-colors@npm:0.74.1"
   checksum: a8625a2ed4f2595c9e1a0b0877ca8ab02dab243ced6bf98c82c328c2c125ca31dd3afd1f2940f2c114af2c309b28ad24da98aa9519a761a2df796c6968c055ec
@@ -18017,6 +18017,7 @@ __metadata:
   dependencies:
     "@commitlint/config-conventional": 17.8.0
     "@react-native/eslint-config": 0.74.0
+    "@react-native/normalize-colors": 0.74.1
     "@release-it/conventional-changelog": 5.1.1
     "@testing-library/react-hooks": 8.0.1
     "@types/jest": 29.5.5
@@ -18050,6 +18051,7 @@ __metadata:
     release-it: 16.2.1
     typescript: 5.2.2
   peerDependencies:
+    "@react-native/normalize-colors": "*"
     react: "*"
     react-native: "*"
     react-native-web: "*"


### PR DESCRIPTION
## Summary

Fixes  #52

Rather than _always_ normalizing colours, I've opted to only modify the input when required (ie. an `opacity` other than `1` is supplied) this means that the output isn't strictly as consistent, but will be faster and doesn't change the authors intent in the case an unsupported value is supplied that the browser still knows how to handle. (Like the new `color(display-p3 1 0.5 0)` formats)

Otherwise we can just pass the colour through as-is.

## Test plan

I've expanded and tweaked some of the existing tests to try to cover the new code path.