### PR TITLE
docs: mention as const

### DIFF
--- a/docs/src/content/docs/example/variants.mdx
+++ b/docs/src/content/docs/example/variants.mdx
@@ -97,6 +97,8 @@ const stylesheet = createStyleSheet(theme => ({
     }
 }))
 ```
+Remember, that if you want to spread styles like so you need to export your theme "as const" for TypeScript.
+This is how React Native types works, and you can see the same behavior with StyleSheet.create.
 
 Now, let's create another variant, e.g., Heading:
 

--- a/docs/src/content/docs/start/setup.mdx
+++ b/docs/src/content/docs/start/setup.mdx
@@ -37,7 +37,7 @@ import Seo from '../../../components/Seo.astro'
         lg: 8,
         xl: 12
       }
-    }
+    } as const
     ```
 
     or something more advanced with nested objects / functions:
@@ -76,8 +76,10 @@ import Seo from '../../../components/Seo.astro'
           return `rgba(${rgb.at(0)}, ${rgb.at(1)}, ${rgb.at(2)}, ${opacity})`
         }
       }
-    }
+    } as const
     ```
+
+    It's good to add "as const" to the end of your theme object to make sure TypeScript knows it's a constant object and not a mutable one. It also allows you to spread your partial theme object into a full theme object without TypeScript complaining.
 
     ### Create breakpoints
 
@@ -93,8 +95,10 @@ import Seo from '../../../components/Seo.astro'
         xl: 1200,
         superLarge: 2000,
         tvLike: 4000
-    }
+    } as const
     ```
+
+    It's good to add "as const" to the end of your breakpoints object to make sure TypeScript knows it's a constant object and not a mutable one.
 
     ### Wrap your app with UnistylesTheme to inject theme
 


### PR DESCRIPTION
## Summary

Mention "as const" for theme to reduce the number of reported issues about types.

