### PR TITLE
fix: lowercasing breakpoints as users may use camelCase

### DIFF
--- a/src/utils/breakpoints.ts
+++ b/src/utils/breakpoints.ts
@@ -118,7 +118,7 @@ export const getValueForBreakpoint = <B extends Breakpoints>(
     }
 
     // if no custom media query, or didn't match, proceed with defined breakpoints
-    const unifiedKey = breakpoint.toLowerCase()
+    const unifiedKey = breakpoint
     const directBreakpoint = value[unifiedKey]
 
     // if there is a direct key like 'sm' or 'md', or value for this key exists but its undefined


### PR DESCRIPTION
## Summary

Fixes #64 
We shouldn't lowercase media queries as users may use camelCase like `superLarge`

## Test plan

Tested locally