### PR TITLE
fix: unsetting shadowOffset & textShadowOffset styles

### DIFF
--- a/src/utils/styles.ts
+++ b/src/utils/styles.ts
@@ -64,7 +64,7 @@ export const parseStyle = <T, B extends Breakpoints>(
     screenSize: ScreenSize,
     breakpointPairs: SortedBreakpointEntries<B>
 ): T => {
-    const entries = Object.entries(style) as [[
+    const entries = Object.entries(style || {}) as [[
         keyof T,
         CustomNamedStyles<T, B> | Record<keyof B & string, string | number | undefined>]
     ]


### PR DESCRIPTION
## Summary

Reported in #67 . Users are unable to unset the shadowOffset & textShadowOffset styles

## Test plan

Tested locally on mobile and web