### PR TITLE
fix: android build in react native 0.73+

### DIFF
--- a/android/src/main/java/com/unistyles/UnistylesModule.kt
+++ b/android/src/main/java/com/unistyles/UnistylesModule.kt
@@ -80,12 +80,14 @@ class UnistylesModule(reactContext: ReactApplicationContext) : ReactContextBaseJ
             System.loadLibrary("unistyles")
             val config = this.getConfig()
 
-            this.nativeInstall(
-                this.reactApplicationContext.javaScriptContextHolder.get(),
-                config["width"] as Int,
-                config["height"] as Int,
-                config["colorScheme"] as String
-            )
+            this.reactApplicationContext.javaScriptContextHolder?.let {
+                this.nativeInstall(
+                    it.get(),
+                    config["width"] as Int,
+                    config["height"] as Int,
+                    config["colorScheme"] as String
+                )
+            }
 
             Log.i(NAME, "Installed Unistyles \uD83E\uDD84!")
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary
Fix android build when use React Native 0.73+ with Java 17. 

React Native recently added Nullable to javaScriptContextHolder:

`…UnistylesModule.kt:84:69 Only safe (?.) or non-null asserted (!!.) calls are allowed on a nullable receiver of type JavaScriptContextHolder?
`

![SCR-20231205-roil](https://github.com/jpudysz/react-native-unistyles/assets/21174859/18f6b6a8-ed38-4ca5-9224-7540f74999cc)

Fixed with Android sugestion

![SCR-20231205-royj](https://github.com/jpudysz/react-native-unistyles/assets/21174859/2d2ffc8a-42a8-43a7-8b9c-6a5eeb9a2b11)

## Test plan

Build successful with react native 0.73+

![SCR-20231205-rpwo](https://github.com/jpudysz/react-native-unistyles/assets/21174859/75aa8c11-36fb-4939-9646-9fd58dc73428)


Related links

[RN 0.72.7 ](https://github.com/facebook/react-native/blob/52904ffc420aaaf8a396a63c86b584b3967965a9/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactContext.java#L529)

[RN 0.73-rc.8](https://github.com/facebook/react-native/blob/6a4b434c8faa88c5b29ecf998c502a47fedc081b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactContext.java#L542) Nullable

https://github.com/microsoft/react-native-test-app/pull/1404
https://github.com/mrousavy/react-native-vision-camera/issues/2207
