### PR TITLE
fix: dependency array for no theme

### DIFF
--- a/src/useStyles.ts
+++ b/src/useStyles.ts
@@ -47,7 +47,7 @@ export const useStyles = <ST extends StyleSheetWithSuperPowers>(
                     !isWeb || !unistyles.registry.config.experimentalCSSMediaQueries)
                 )
             })
-        }, {}), [parsedStyles, variants, plugins]
+        }, {}), [parsedStyles, variants, plugins, layout]
     )
 
     useCSS(dynamicStyleSheet as ReactNativeStyleSheet<ST>)


### PR DESCRIPTION
## Summary

For no registered theme we need one more dep in dependency array of `useStyles`.

Fixes #121 
