### PR TITLE
docs: compound variants typo

### DIFF
--- a/docs/src/content/docs/reference/compound-variants.mdx
+++ b/docs/src/content/docs/reference/compound-variants.mdx
@@ -86,7 +86,7 @@ const stylesheet = createStyleSheet({
             }
         }
     },
-    extraStyle = (size, color) => {
+    extraStyle: (size, color) => {
         if (size === 'small' && color === 'red') {
             return {
                 borderWidth: 1,


### PR DESCRIPTION
## Summary

Just a one-line typo correction in "Compound Variants" docs code snippet.