### PR TITLE
fix: initial screen height for ios

### DIFF
--- a/ios/UnistylesModule.mm
+++ b/ios/UnistylesModule.mm
@@ -73,7 +73,7 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(install) {
 void registerUnistylesHostObject(jsi::Runtime &runtime, UnistylesModule* weakSelf) {
     auto unistylesRuntime = std::make_shared<UnistylesRuntime>(
         (int)weakSelf.platform.initialWidth,
-        (int)weakSelf.platform.initialWidth,
+        (int)weakSelf.platform.initialHeight,
         weakSelf.platform.initialColorScheme,
         weakSelf.platform.initialContentSizeCategory
     );


### PR DESCRIPTION
## Summary

Initial window height reported for iOS was equal to window width. Fixes: #135 
