### PR TITLE
feat: add proguard rule in library level

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -42,6 +42,7 @@ android {
                 arguments "-DANDROID_STL=c++_shared"
             }
         }
+        consumerProguardFiles 'proguard-rules.pro'
     }
 
     buildFeatures {

--- a/android/proguard-rules.pro
+++ b/android/proguard-rules.pro
@@ -1,0 +1,1 @@
+-keep class com.unistyles.** { *; }

--- a/android/proguard-rules.pro
+++ b/android/proguard-rules.pro
@@ -1,1 +1,3 @@
 -keep class com.unistyles.** { *; }
+-keep class com.facebook.react.fabric.** { *; }
+

--- a/docs/src/content/docs/reference/faq.mdx
+++ b/docs/src/content/docs/reference/faq.mdx
@@ -81,13 +81,4 @@ If you encounter any issues with `array.prototype.at`, please consider using a [
 
 Yes, Unistyles supports both macOS with `react-native-macos` and Windows with `react-native-windows` packages. 
 
-### My release app is crashing on startup (Android) with ProGuard enabled
-
-It's essential to keep the Unistyles code from being obfuscated. Unistyles is using JNI with reflection, and ProGuard can break it.
-To fix this, add the following line to your `proguard-rules.pro` file:
-
-```proguard
--keep class com.unistyles.** { *; }
-```
-
 </Seo>


### PR DESCRIPTION
## Summary

Add required proguard rule at the library level to prevent crashes when proguard is enabled.

Fixes #153 

Related https://github.com/jpudysz/react-native-unistyles/commit/bba3e9fc5f894b552a768079d945bda9f101b1d0

Note: In draft as I am still testing the build in release with proguard.