### PR TITLE
fix: dont trigger layout config change on app resume

### DIFF
--- a/android/src/main/java/com/unistyles/Insets.kt
+++ b/android/src/main/java/com/unistyles/Insets.kt
@@ -48,7 +48,7 @@ class UnistylesInsets(private val reactApplicationContext: ReactApplicationConte
 
         // available from Android 6.0
         val window = reactApplicationContext.currentActivity?.window ?: return Insets(0, 0, 0, 0)
-        val systemInsets = window.decorView.rootWindowInsets
+        val systemInsets = window.decorView.rootWindowInsets ?: return Insets(0, 0, 0, 0)
 
         val top = (systemInsets.systemWindowInsetTop / density).roundToInt()
         val bottom = (systemInsets.systemWindowInsetBottom / density).roundToInt()

--- a/android/src/main/java/com/unistyles/UnistylesModule.kt
+++ b/android/src/main/java/com/unistyles/UnistylesModule.kt
@@ -67,13 +67,14 @@ class UnistylesModule(reactContext: ReactApplicationContext) : ReactContextBaseJ
 
     @Deprecated("Deprecated in Java")
     override fun onCatalystInstanceDestroy() {
-        val activity = currentActivity ?: return
-
         this.stopLayoutListener()
         reactApplicationContext.unregisterReceiver(configurationChangeReceiver)
         runnable?.let { drawHandler.removeCallbacks(it) }
         reactApplicationContext.removeLifecycleEventListener(this)
-        this.nativeDestroy()
+
+        if (this.isCxxReady) {
+            this.nativeDestroy()
+        }
     }
 
     //endregion
@@ -144,7 +145,9 @@ class UnistylesModule(reactContext: ReactApplicationContext) : ReactContextBaseJ
 
             false
         } catch (e: Exception) {
-            false
+            this.isCxxReady = false
+
+            return false
         }
     }
 
@@ -240,7 +243,6 @@ class UnistylesModule(reactContext: ReactApplicationContext) : ReactContextBaseJ
     override fun onHostResume() {
         if (isCxxReady) {
             this.onConfigChange()
-            this.onLayoutConfigChange()
         }
 
         this.setupLayoutListener()


### PR DESCRIPTION
## Summary

- Don't trigger layout config change on app resume, assume that `systemInsets` may be nullable. Fixes #176 
- Call native destroy only when unistyles was initialized. Fixes #174 
