### PR TITLE
docs: add jest.setup.js test example

### DIFF
--- a/docs/src/content/docs/reference/testing.mdx
+++ b/docs/src/content/docs/reference/testing.mdx
@@ -27,6 +27,11 @@ In order to use the library mocks you need to either use `jest` or set `process.
   "test": "NODE_ENV=test vitest"
 },
 ```
+Alternatively, you can import your Unistyles themes into `jest.setup.js`.
+```js
+// jest.setup.js
+import '../unistyles';
+```
 
 ### NativeEventEmitter
 


### PR DESCRIPTION
As per https://github.com/jpudysz/react-native-unistyles/discussions/88#discussioncomment-9203131

Thought it would be worthwhile calling this out directly. For some reason using `NODE_ENV=test` wasn't working with my setup.





