### PR TITLE
Support breakpoints when iPadOS window frame size changes

### DIFF
--- a/ios/platform/Platform_iOS.mm
+++ b/ios/platform/Platform_iOS.mm
@@ -9,15 +9,17 @@
 - (instancetype)init {
     self = [super init];
     if (self) {
-        UIScreen *screen = [UIScreen mainScreen];
+        UIViewController *presentedViewController = RCTPresentedViewController();
+        CGRect windowFrame = presentedViewController.view.window.frame;
+
         UIContentSizeCategory contentSizeCategory = [[UIApplication sharedApplication] preferredContentSizeCategory];
 
-        self.initialScreen = {(int)screen.bounds.size.width, (int)screen.bounds.size.height};
+        self.initialScreen = {(int)windowFrame.size.width, (int)windowFrame.size.height};
         self.initialColorScheme = [self getColorScheme];
         self.initialContentSizeCategory = [self getContentSizeCategory:contentSizeCategory];
         self.initialStatusBar = [self getStatusBarDimensions];
         self.initialInsets = [self getInsets];
-        
+
         [self setupListeners];
     }
     return self;
@@ -32,6 +34,9 @@
                                           name: UIContentSizeCategoryDidChangeNotification
                                           object: nil];
     [[NSNotificationCenter defaultCenter] removeObserver:self
+                                          name:RCTWindowFrameDidChangeNotification
+                                          object:nil];
+    [[NSNotificationCenter defaultCenter] removeObserver:self
                                           name: RCTUserInterfaceStyleDidChangeNotification
                                           object: nil];
     [[NSNotificationCenter defaultCenter] removeObserver:self
@@ -41,8 +46,12 @@
 
 - (void)setupListeners {
     [[NSNotificationCenter defaultCenter] addObserver:self
-                                             selector:@selector(onOrientationChange:)
+                                             selector:@selector(onWindowChange:)
                                                  name:UIDeviceOrientationDidChangeNotification
+                                               object:nil];
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(onWindowChange:)
+                                                 name:RCTWindowFrameDidChangeNotification
                                                object:nil];
     [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(onAppearanceChange:)
@@ -70,10 +79,12 @@
     }
 }
 
-- (void)onOrientationChange:(NSNotification *)notification {
+- (void)onWindowChange:(NSNotification *)notification {
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.1 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
-        UIScreen *mainScreen = [UIScreen mainScreen];
-        Dimensions screen = {(int)mainScreen.bounds.size.width, (int)mainScreen.bounds.size.height};
+        UIViewController *presentedViewController = RCTPresentedViewController();
+
+        CGRect windowFrame = presentedViewController.view.frame;
+        Dimensions screen = {(int)windowFrame.size.width, (int)windowFrame.size.height};
         Insets insets = [self getInsets];
         Dimensions statusBar = [self getStatusBarDimensions];
         Dimensions navigationBar = [self getNavigationBarDimensions];
@@ -101,13 +112,13 @@
 - (Insets)getInsets {
     UIWindow *window = UIApplication.sharedApplication.windows.firstObject;
     UIEdgeInsets safeArea = window.safeAreaInsets;
-    
+
     return {(int)safeArea.top, (int)safeArea.bottom, (int)safeArea.left, (int)safeArea.right};
 }
 
 - (Dimensions)getStatusBarDimensions {
     CGRect statusBarFrame = UIApplication.sharedApplication.statusBarFrame;
-    
+
     return {(int)statusBarFrame.size.width, (int)statusBarFrame.size.height};
 }
 
@@ -119,51 +130,51 @@
     if ([contentSizeCategory isEqualToString:UIContentSizeCategoryExtraExtraExtraLarge]) {
         return std::string([@"xxxLarge" UTF8String]);
     }
-    
+
     if ([contentSizeCategory isEqualToString:UIContentSizeCategoryExtraExtraLarge]) {
         return std::string([@"xxLarge" UTF8String]);
     }
-    
+
     if ([contentSizeCategory isEqualToString:UIContentSizeCategoryExtraLarge]) {
         return std::string([@"xLarge" UTF8String]);
     }
-    
+
     if ([contentSizeCategory isEqualToString:UIContentSizeCategoryLarge]) {
         return std::string([@"Large" UTF8String]);
     }
-    
+
     if ([contentSizeCategory isEqualToString:UIContentSizeCategoryMedium]) {
         return std::string([@"Medium" UTF8String]);
     }
-    
+
     if ([contentSizeCategory isEqualToString:UIContentSizeCategorySmall]) {
         return std::string([@"Small" UTF8String]);
     }
-    
+
     if ([contentSizeCategory isEqualToString:UIContentSizeCategoryExtraSmall]) {
         return std::string([@"xSmall" UTF8String]);
     }
-    
+
     if ([contentSizeCategory isEqualToString:UIContentSizeCategoryAccessibilityMedium]) {
         return std::string([@"accessibilityMedium" UTF8String]);
     }
-    
+
     if ([contentSizeCategory isEqualToString:UIContentSizeCategoryAccessibilityLarge]) {
         return std::string([@"accessibilityLarge" UTF8String]);
     }
-    
+
     if ([contentSizeCategory isEqualToString:UIContentSizeCategoryAccessibilityExtraLarge]) {
         return std::string([@"accessibilityExtraLarge" UTF8String]);
     }
-    
+
     if ([contentSizeCategory isEqualToString:UIContentSizeCategoryAccessibilityExtraExtraLarge]) {
         return std::string([@"accessibilityExtraExtraLarge" UTF8String]);
     }
-    
+
     if ([contentSizeCategory isEqualToString:UIContentSizeCategoryAccessibilityExtraExtraExtraLarge]) {
         return std::string([@"accessibilityExtraExtraExtraLarge" UTF8String]);
     }
-    
+
     return std::string([@"unspecified" UTF8String]);
 }
 


### PR DESCRIPTION
## Summary

Fixes https://github.com/jpudysz/react-native-unistyles/issues/208

<!-- Explain the motivation for this PR. Include "Fixes #<number>" if applicable. -->

I'm not an iOS developer, but I thought I'd take a stab at figuring out how to handle the iPadOS window frame sizing. I thought it'd be best to do it in a way that works across all iOS products to keep the code simple.

I think the solution here ended up being fairly clean and I was able to test on a physical iPad and an iPhone simulator to validate the breakpoints are working as intended on both operating systems.