### PR TITLE
fix: avoid computing incorrect ios screen sizes when the app is backgrounded

### DIFF
--- a/ios/platform/Platform_iOS.mm
+++ b/ios/platform/Platform_iOS.mm
@@ -108,6 +108,18 @@
 
 - (void)onWindowChange:(NSNotification *)notification {
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.1 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        UIApplicationState appState = [UIApplication sharedApplication].applicationState;
+
+
+        /*
+            We can still receive events when the app is backgrounding, and this can result in a new smaller screen size being computed erronesouly.
+            When the app is brought back to the foreground this can result in jank as the correct screen size is recomputed.
+            Avoiding this behavior is as simple as making sure the appState is not background before recomputing our screen size.
+        */
+        if (appState == UIApplicationStateBackground) {
+            return;
+        }
+
         Screen screen = [self getScreenDimensions];
         Insets insets = [self getInsets];
         Dimensions statusBar = [self getStatusBarDimensions];

--- a/ios/platform/Platform_iOS.mm
+++ b/ios/platform/Platform_iOS.mm
@@ -110,12 +110,6 @@
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.1 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
         UIApplicationState appState = [UIApplication sharedApplication].applicationState;
 
-
-        /*
-            We can still receive events when the app is backgrounding, and this can result in a new smaller screen size being computed erronesouly.
-            When the app is brought back to the foreground this can result in jank as the correct screen size is recomputed.
-            Avoiding this behavior is as simple as making sure the appState is not background before recomputing our screen size.
-        */
         if (appState == UIApplicationStateBackground) {
             return;
         }


### PR DESCRIPTION
## Summary

I've noticed in the last couple of days a small issue with #209 when the app is backgrounded and then foregrounded https://github.com/jpudysz/react-native-unistyles/pull/209#issuecomment-2191845116

I was skeptical the fix would be as simple as checking the app state before computing the current screen size, but it seems to work! I've been trying to reproduce the jank while foregrounding one of my apps (that has a screen with more significant changes between breakpoints, which is where I first noticed this bug) and I haven't been able to reproduce at all!

Here's an example of the behavior cycling between 2 builds of the same app, the first with 2.8.0-beta1 and the second with the changes included in this PR:
https://share.icloud.com/photos/049KH9cdeymdJfySqtHKavPTA