### PR TITLE
chore: parse fontscale back to float

### DIFF
--- a/src/core/UnistyleRegistry.ts
+++ b/src/core/UnistyleRegistry.ts
@@ -60,7 +60,7 @@ export class UnistyleRegistry {
             this.unistylesBridge.addPlugin(cssMediaQueriesPlugin.name, false)
         }
 
-        if (config.windowResizeDebounceTimeMs !== undefined) {
+        if (isWeb && config.windowResizeDebounceTimeMs !== undefined) {
             this.unistylesBridge.setWindowResizeDebounceTimeMs(config.windowResizeDebounceTimeMs)
         }
 

--- a/src/core/UnistylesRuntime.ts
+++ b/src/core/UnistylesRuntime.ts
@@ -170,9 +170,7 @@ export class UnistylesRuntime {
      * @returns - The font scale
      */
     public get fontScale() {
-        const fontScale = this.unistylesBridge.fontScale
-
-        return fontScale === 1.0 ? 1 : fontScale.toFixed(2)
+        return parseFloat(this.unistylesBridge.fontScale.toFixed(2))
     }
 
     /**


### PR DESCRIPTION
## Summary

Fixes issue with bad type returned from `UnistylesRuntime.fontScale`