### PR TITLE
feat: improve bottom insets

### DIFF
--- a/android/src/main/java/com/unistyles/Platform.kt
+++ b/android/src/main/java/com/unistyles/Platform.kt
@@ -99,7 +99,12 @@ class Platform(private val reactApplicationContext: ReactApplicationContext) {
 
         val insets = insetsCompat.getInsets(WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout())
 
-        this.insets = Insets(statusBarTopInset, insets.bottom, insets.left, insets.right)
+        // reports inset bottom as 0 when keyboard is visible
+        // otherwise it will break other libraries that manipulates bottom insets
+        val imeInsets = insetsCompat.getInsets(WindowInsetsCompat.Type.ime())
+        val insetsBottom = if (imeInsets.bottom > 0) 0 else insets.bottom
+
+        this.insets = Insets(statusBarTopInset, insetsBottom, insets.left, insets.right)
     }
 
     fun getInsets(): Insets {


### PR DESCRIPTION
## Summary

This PR fixes #230 as Unistyles was reading insets forced by other libraries like `react-native-keyboard-controller`.
In other words when keyboard is visible, then bottom insets is always 0. It also helps to create sticky inputs etc.