### PR TITLE
feat: export UniStyle(View|Text|Image) types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import { unistyles } from './core'
 import { mq } from './utils'
 import { useInitialTheme } from './hooks'
-import type { UnistylesPlugin, UnistylesValues, ExtractVariantNames } from './types'
+import type { UnistylesPlugin, UnistylesValues, UnistyleText, UnistyleView, UnistyleImage, ExtractVariantNames } from './types'
 import type { UnistylesThemes, UnistylesBreakpoints } from './global'
 import { ScreenOrientation, AndroidContentSizeCategory, IOSContentSizeCategory } from './common'
 import { useStyles } from './useStyles'
@@ -48,5 +48,8 @@ export type {
     UnistylesBreakpoints,
     UnistylesPlugin,
     UnistylesValues,
+    UnistyleText,
+    UnistyleView,
+    UnistyleImage,
     ExtractVariantNames as UnistylesVariants
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -14,7 +14,10 @@ export type {
     StyleSheetWithSuperPowers,
     StyleSheet,
     AllAvailableKeys,
-    UnistylesValues
+    UnistylesValues,
+    UnistyleText,
+    UnistyleView,
+    UnistyleImage
 } from './stylesheet'
 export type { ReactNativeStyleSheet } from './breakpoints'
 export type { ExtractVariantNames } from './variants'

--- a/src/types/stylesheet.ts
+++ b/src/types/stylesheet.ts
@@ -6,9 +6,9 @@ import type { UnistylesMiniRuntime } from '../core'
 // these props are treated differently to nest breakpoints and media queries
 type NestedKeys = 'shadowOffset' | 'transform' | 'textShadowOffset'
 
-type UnistyleView = Omit<ViewStyle, NestedKeys>
-type UnistyleText = Omit<TextStyle, NestedKeys>
-type UnistyleImage = Omit<ImageStyle, NestedKeys>
+export type UnistyleView = Omit<ViewStyle, NestedKeys>
+export type UnistyleText = Omit<TextStyle, NestedKeys>
+export type UnistyleImage = Omit<ImageStyle, NestedKeys>
 
 type UnistyleNestedStyles = {
     shadowOffset?: ToDeepUnistyles<ShadowOffset>,


### PR DESCRIPTION
## Summary

<!-- Explain the motivation for this PR. Include "Fixes #<number>" if applicable. -->
I want to create some reusable Object and type them correctly
```
type Font = {
    [key: string]: UnistyleText
}

export const fonts: Font = {
    body: {
        fontSize: 16,
        fontWeight: 400,
        lineHeight: 24
    }
}

const stylesheet = createStyleSheet(theme => ({
  body: {
    ...fonts.body
  }
}));
```

It throws error if UnistyleText isn't used