### PR TITLE
feat: allow createStyleSheet to take UniStyle(Text|Image|View)

### DIFF
--- a/examples/bare/src/App.tsx
+++ b/examples/bare/src/App.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { useStyles, createStyleSheet, UnistylesRuntime } from 'react-native-unistyles'
 import { View, Text, Pressable } from 'react-native'
 import './styles'
+import type { UnistyleText } from '../../../lib/typescript/src'
 
 export const App: React.FunctionComponent = () => {
     const { styles } = useStyles(stylesheet)
@@ -32,6 +33,12 @@ export const App: React.FunctionComponent = () => {
     )
 }
 
+const fonts: {bold: UnistyleText} = {
+    bold: {
+        fontWeight: 'bold'
+    }
+}
+
 const stylesheet = createStyleSheet((theme, rt) => ({
     container: {
         flex: 1,
@@ -45,8 +52,8 @@ const stylesheet = createStyleSheet((theme, rt) => ({
         color: theme.colors.typography
     },
     highlight: {
-        fontWeight: 'bold',
-        color: theme.colors.accent
+        color: theme.colors.accent,
+        ...fonts.bold
     },
     note: {
         color: theme.colors.typography
@@ -63,7 +70,5 @@ const stylesheet = createStyleSheet((theme, rt) => ({
         borderRadius: 12,
         marginBottom: rt.insets.bottom + 20
     },
-    bold: {
-        fontWeight: 'bold'
-    }
+    bold: fonts.bold
 }))

--- a/src/types/stylesheet.ts
+++ b/src/types/stylesheet.ts
@@ -43,8 +43,9 @@ export type UnistylesValues = {
     [propName in NestedKeys]?: UnistyleNestedStyles[propName]
 }
 
+type StyleSheetValues = UnistylesValues | UnistyleText | UnistyleImage | UnistyleView
 export type StyleSheet = {
-    [styleName: string]: UnistylesValues | ((...args: any) => UnistylesValues)
+    [styleName: string]: StyleSheetValues | ((...args: any) => StyleSheetValues)
 }
 
 export type StyleSheetWithSuperPowers = ((theme: UnistylesTheme, miniRuntime: UnistylesMiniRuntime) => StyleSheet) | StyleSheet


### PR DESCRIPTION
## Summary

Allow createStyleSheet to take UniStyle types

<!-- Explain the motivation for this PR. Include "Fixes #<number>" if applicable. -->

I want to reuse some common styles for typography for example.
Currently, it will introduce a typing errors if I use UnistyleText.
Added examples.
Without the change in stylesheet.ts, `npm run tsc` will throw an error.
<img width="606" alt="image" src="https://github.com/user-attachments/assets/46464ae4-924e-4ddf-8fe9-05da21ab910d">

Issues are gone after the change
<img width="715" alt="image" src="https://github.com/user-attachments/assets/76e3995b-4794-4bf2-ae7d-67d2bf064b47">


