### PR TITLE
feat: export UnistylesTheme

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import { unistyles } from './core'
 import { mq } from './utils'
 import { useInitialTheme } from './hooks'
-import type { UnistylesPlugin, UnistylesValues, UnistyleText, UnistyleView, UnistyleImage, ExtractVariantNames } from './types'
+import type { UnistylesPlugin, UnistylesValues, UnistyleText, UnistyleView, UnistyleImage, ExtractVariantNames, UnistylesTheme } from './types'
 import type { UnistylesThemes, UnistylesBreakpoints } from './global'
 import { ScreenOrientation, AndroidContentSizeCategory, IOSContentSizeCategory } from './common'
 import { useStyles } from './useStyles'
@@ -44,6 +44,7 @@ export {
 }
 
 export type {
+    UnistylesTheme,
     UnistylesThemes,
     UnistylesBreakpoints,
     UnistylesPlugin,


### PR DESCRIPTION
## Summary
Export UnistylesTheme

<!-- Explain the motivation for this PR. Include "Fixes #<number>" if applicable. -->

I am implementing customised styles for border with some business logics.
I want to move the logic into a pure function. e.g
```
const getBorderColor = (theme: UnistylesThemes[keyof UnistylesThemes], focus: boolean, error: boolean) => {
    if (error) {
        return theme.colors.criticalDark;
    }
    ...
}
```

I can mock UnistylesTheme from local via UnistylesThemes[keyof UnistylesThemes] but it's better to use UnistylesTheme directly.
