### PR TITLE
docs: fix variant headers

### DIFF
--- a/docs/src/content/docs/reference/variants.mdx
+++ b/docs/src/content/docs/reference/variants.mdx
@@ -181,7 +181,7 @@ Boolean variants respects other rules, eg. `false` is not equal to `default`. To
 to fallback to `default` variant you need to pass `undefined` or `{}`.
 :::
 
-###Default variant
+### Default variant
 
 You can define a `default` variant that will be used when you don't pass any variant to the `useStyles` hook:
 
@@ -206,7 +206,7 @@ const stylesheet = createStyleSheet(theme => ({
 }
 ```
 
-###Options to select the variant
+### Options to select the variant
 
 If you pass `undefined` or `empty object` Unsityles will try to find the `default` variant in your stylesheet:
 


### PR DESCRIPTION
## Summary

The docs page for the [variants](https://reactnativeunistyles.vercel.app/reference/variants/) is not rendering the heading correctly for two of the sections due to a missing space.