### PR TITLE
fix: build fail on Android, cast float to double - support React Native 0.72

### DIFF
--- a/cxx/UnistylesImpl.cpp
+++ b/cxx/UnistylesImpl.cpp
@@ -234,11 +234,11 @@ jsi::Value UnistylesRuntime::getNavigationBar(jsi::Runtime& rt, std::string fnNa
 }
 
 jsi::Value UnistylesRuntime::getPixelRatio(jsi::Runtime& rt, std::string fnName) {
-    return jsi::Value(roundf(this->pixelRatio * 100)/ 100);
+    return jsi::Value(static_cast<double>(roundf(this->pixelRatio * 100)/ 100));
 }
 
 jsi::Value UnistylesRuntime::getFontScale(jsi::Runtime& rt, std::string fnName) {
-    return jsi::Value(roundf(this->fontScale * 100) / 100);
+    return jsi::Value(static_cast<double>(roundf(this->fontScale * 100) / 100));
 }
 
 std::optional<jsi::Value> UnistylesRuntime::setThemes(jsi::Runtime& rt, const jsi::Value& value) {


### PR DESCRIPTION
## Summary
Hello, thank you very much for creating such a great open-source project.
I installed version 2.9.1 to use react-native-unistyles. However, I encountered the following error while building the Android app.

```
[1/7] Building CXX object CMakeFiles/unistyles.dir/src/main/cxx/helpers.cpp.o
[2/7] Building CXX object CMakeFiles/unistyles.dir/.../node_modules/react-native-unistyles/cxx/UnistylesRuntime.cpp.o
[3/7] Building CXX object CMakeFiles/unistyles.dir/.../node_modules/react-native-unistyles/cxx/UnistylesModel.cpp.o
[4/7] Building CXX object CMakeFiles/unistyles.dir/.../node_modules/react-native-unistyles/cxx/UnistylesImpl.cpp.o
FAILED: CMakeFiles/unistyles.dir/.../node_modules/react-native-unistyles/cxx/UnistylesImpl.cpp.o

.gradle/caches/transforms-3/ef2d7697779c544a76e341d3d27be809/transformed/jetified-react-android-0.72.6-debug/prefab/modules/jsi/include/jsi/jsi.h:1102:43: error: no matching function for call to 'kindOf'
  /* implicit */ Value(T&& other) : Value(kindOf(other)) {
                                          ^~~~~~

error: static_assert failed due to requirement 'std::is_base_of<facebook::jsi::Symbol, float>::value || std::is_base_of<facebook::jsi::BigInt, float>::value || std::is_base_of<facebook::jsi::String, float>::value || std::is_base_of<facebook::jsi::Object, float>::value' "Value cannot be implicitly move-constructed from this type"
.gradle/caches/transforms-3/ef2d7697779c544a76e341d3d27be809/transformed/jetified-react-android-0.72.6-debug/prefab/modules/jsi/include/jsi/jsi.h:1102:43: error: no matching function for call to 'kindOf'
/node_modules/react-native-unistyles/cxx/UnistylesImpl.cpp:237:12: note: in instantiation of function template specialization 'facebook::jsi::Value::Value<float>' requested here
.gradle/caches/transforms-3/ef2d7697779c544a76e341d3d27be809/transformed/jetified-react-android-0.72.6-debug/prefab/modules/jsi/include/jsi/jsi.h:1350:30: note: candidate function not viable: no known conversion from 'float' to 'const facebook::jsi::Symbol' for 1st argument
.gradle/caches/transforms-3/ef2d7697779c544a76e341d3d27be809/transformed/jetified-react-android-0.72.6-debug/prefab/modules/jsi/include/jsi/jsi.h:1353:30: note: candidate function not viable: no known conversion from 'float' to 'const facebook::jsi::BigInt' for 1st argument
.gradle/caches/transforms-3/ef2d7697779c544a76e341d3d27be809/transformed/jetified-react-android-0.72.6-debug/prefab/modules/jsi/include/jsi/jsi.h:1356:30: note: candidate function not viable: no known conversion from 'float' to 'const facebook::jsi::String' for 1st argument
.gradle/caches/transforms-3/ef2d7697779c544a76e341d3d27be809/transformed/jetified-react-android-0.72.6-debug/prefab/modules/jsi/include/jsi/jsi.h:1359:30: note: candidate function not viable: no known conversion from 'float' to 'const facebook::jsi::Object' for 1st argument
```

So, I successfully built the project after modifying `react-native-unistyles/cxx/UnistylesImpl.cpp` as requested. I'm not sure why the implicit conversion fails, but there are no functional issues. I’m submitting this PR because other users might encounter the same problem.

<!-- Explain the motivation for this PR. Include "Fixes #<number>" if applicable. -->
