### PR TITLE
docs: add error example for theme object structure

### DIFF
--- a/docs/src/content/docs/reference/theming.mdx
+++ b/docs/src/content/docs/reference/theming.mdx
@@ -84,6 +84,10 @@ Where `name` is the unique name of your theme.
 
 :::tip
 Your themes may have different shapes, but it's generally not recommended.
+
+For example, at runtime, if you reference a property from `lightTheme` that doesn’t exist in `darkTheme` or any other theme, the value will default to `undefined` when the app switches to that theme. This can lead to unpredictable behavior in your app.
+
+TypeScript will warn you if you attempt to use a property that isn’t defined across all your themes.
 :::
 
 ### Select theme


### PR DESCRIPTION
## Summary

Fixes #269 

I added this paragraph to explain why all the `theme` objects must share the same structure following the issue I opened. I believe this will make the documentation clearer.
