### PR TITLE
feat: remove undefined transforms

### DIFF
--- a/src/utils/styles.ts
+++ b/src/utils/styles.ts
@@ -35,7 +35,16 @@ export const parseStyle = <T extends RNStyle>(
 
         // transforms
         if (key === 'transform' && Array.isArray(value)) {
-            acc[key] = value.map(value => parseStyle(value, variant))
+            acc[key] = value
+                .map(value => parseStyle(value, variant))
+                .filter(value => {
+                    // remove undefined values
+                    if (typeof value === 'object') {
+                        return Object.values(value).at(0) !== undefined
+                    }
+
+                    return true
+                })
 
             return acc
         }


### PR DESCRIPTION
## Summary

It seems that at some point there was a change in the core of React Native, and we can't longer return following objects:

```tsx
<View
  style={{
    transform: [
       { scale: undefined }
    ]
  }}
/>
```

but its possible with breakpoints eg.:

```tsx
{
    transform: [
       { 
         scale: {
           md: 1,
           lg: 2   
         }
       }
    ]
  }
```

and our breakpoint is `sm`.

This PR simply filters transforms that are undefined.

This can for sure be reproduced with RN 0.74 and RN 0.75
