### PR TITLE
feat: add option to disable animated insets

### DIFF
--- a/android/src/main/cxx/platform.cpp
+++ b/android/src/main/cxx/platform.cpp
@@ -49,6 +49,10 @@ void makeShared(JNIEnv *env, jobject unistylesModule, std::shared_ptr<UnistylesR
         setRootViewBackgroundColor(env, unistylesModule, color, alpha);
     });
 
+    unistylesRuntime->setDisableAnimatedInsetsAndroidCallback([=]() {
+        disableAnimatedInsets(env, unistylesModule);
+    });
+
     Screen screen = getScreenDimensions(env, unistylesModule);
 
     unistylesRuntime->screen = Dimensions{screen.width, screen.height};
@@ -60,6 +64,20 @@ void makeShared(JNIEnv *env, jobject unistylesModule, std::shared_ptr<UnistylesR
     unistylesRuntime->fontScale = screen.fontScale;
     unistylesRuntime->pixelRatio = screen.pixelRatio;
     unistylesRuntime->rtl = getIsRTL(env, unistylesModule);
+}
+
+void disableAnimatedInsets(JNIEnv *env, jobject unistylesModule) {
+    jclass cls = env->GetObjectClass(unistylesModule);
+    jfieldID platformFieldId = env->GetFieldID(cls, "platform", "Lcom/unistyles/Platform;");
+    jobject platformInstance = env->GetObjectField(unistylesModule, platformFieldId);
+    jclass platformClass = env->GetObjectClass(platformInstance);
+    jmethodID methodId = env->GetMethodID(platformClass, "disableAnimatedInsets", "()V");
+
+    env->CallVoidMethod(platformInstance, methodId);
+
+    env->DeleteLocalRef(cls);
+    env->DeleteLocalRef(platformInstance);
+    env->DeleteLocalRef(platformClass);
 }
 
 Screen getScreenDimensions(JNIEnv *env, jobject unistylesModule) {

--- a/android/src/main/cxx/platform.h
+++ b/android/src/main/cxx/platform.h
@@ -17,3 +17,4 @@ bool getIsRTL(JNIEnv *env, jobject unistylesModule);
 std::string getContentSizeCategory(JNIEnv *env, jobject unistylesModule);
 void setNavigationBarColor(JNIEnv *env, jobject unistylesModule, std::string color, float alpha);
 void setStatusBarColor(JNIEnv *env, jobject unistylesModule, std::string color, float alpha);
+void disableAnimatedInsets(JNIEnv *env, jobject unistylesModule);

--- a/android/src/main/java/com/unistyles/Platform.kt
+++ b/android/src/main/java/com/unistyles/Platform.kt
@@ -20,11 +20,16 @@ import java.util.Locale
 import kotlin.math.roundToInt
 
 class Platform(private val reactApplicationContext: ReactApplicationContext) {
+    var hasAnimatedInsets = true
     private var insets: Insets = Insets(0, 0, 0, 0)
     private var defaultNavigationBarColor: Int = -1
     private var defaultStatusBarColor: Int = -1
 
     var orientation: Int = reactApplicationContext.resources.configuration.orientation
+
+    fun disableAnimatedInsets() {
+        this.hasAnimatedInsets = false
+    }
 
     @Suppress("DEPRECATION")
     fun getScreenDimensions(): Screen {
@@ -140,10 +145,16 @@ class Platform(private val reactApplicationContext: ReactApplicationContext) {
         }
 
         val insets = insetsCompat.getInsets(WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout())
-        val imeInsets = insetsCompat.getInsets(WindowInsetsCompat.Type.ime())
+
+        if (!hasAnimatedInsets) {
+            this.insets = Insets(statusBarTopInset, insets.bottom, insets.left, insets.right)
+
+            return
+        }
 
         // Android 10 and below - set bottom insets to 0 while keyboard is visible and use default bottom insets otherwise
         // Android 11 and above - animate bottom insets while keyboard is appearing and disappearing
+        val imeInsets = insetsCompat.getInsets(WindowInsetsCompat.Type.ime())
         val insetBottom = when(imeInsets.bottom > 0) {
             true -> {
                 if (Build.VERSION.SDK_INT >= 30 && animatedBottomInsets != null) {

--- a/android/src/main/java/com/unistyles/UnistylesModule.kt
+++ b/android/src/main/java/com/unistyles/UnistylesModule.kt
@@ -154,7 +154,7 @@ class UnistylesModule(reactContext: ReactApplicationContext) : ReactContextBaseJ
                     insets
                 }
 
-                if (Build.VERSION.SDK_INT >= 30) {
+                if (platform.hasAnimatedInsets && Build.VERSION.SDK_INT >= 30) {
                     ViewCompat.setWindowInsetsAnimationCallback(
                         mainView,
                         object : WindowInsetsAnimationCompat.Callback(DISPATCH_MODE_STOP) {

--- a/cxx/UnistylesImpl.cpp
+++ b/cxx/UnistylesImpl.cpp
@@ -298,3 +298,13 @@ jsi::Value UnistylesRuntime::setRootBackgroundColor(jsi::Runtime& rt, std::strin
 jsi::Value UnistylesRuntime::getIsRtl(jsi::Runtime& rt, std::string fnName) {
     return jsi::Value(this->rtl);
 }
+
+jsi::Value UnistylesRuntime::disableAnimatedInsets(jsi::Runtime& rt, std::string fnName) {
+    return HOST_FN(fnName, 1, {
+        if (this->disableAnimatedInsetsAndroid.has_value()) {
+            this->disableAnimatedInsetsAndroid.value()();
+        }
+
+        return jsi::Value::undefined();
+    });
+}

--- a/cxx/UnistylesModel.h
+++ b/cxx/UnistylesModel.h
@@ -66,6 +66,7 @@ struct UnistylesModel {
     std::optional<std::function<void(bool)>> setStatusBarHidden;
     std::optional<std::function<void(bool)>> setImmersiveMode;
     std::optional<std::function<void(std::string, float alpha)>> setRootViewBackgroundColor;
+    std::optional<std::function<void()>> disableAnimatedInsetsAndroid;
 
     void setScreenDimensionsCallback(std::function<Screen()> callback) {
         this->getScreenDimensions = callback;
@@ -102,6 +103,9 @@ struct UnistylesModel {
     }
     void setRootViewBackgroundColorCallback(std::function<void(std::string color, float alpha)> callback) {
         this->setRootViewBackgroundColor = callback;
+    }
+    void setDisableAnimatedInsetsAndroidCallback(std::function<void()> callback) {
+        this->disableAnimatedInsetsAndroid = callback;
     }
 
     Dimensions screen = {0, 0};

--- a/cxx/UnistylesRuntime.h
+++ b/cxx/UnistylesRuntime.h
@@ -35,7 +35,8 @@ struct JSI_EXPORT UnistylesRuntime : public jsi::HostObject, UnistylesModel {
             {"fontScale", BIND_FN(getFontScale)},
             {"setRootViewBackgroundColor", BIND_FN(setRootBackgroundColor)},
             {"setImmersiveMode", BIND_FN(setImmersiveModeEnabled)},
-            {"rtl", BIND_FN(getIsRtl)}
+            {"rtl", BIND_FN(getIsRtl)},
+            {"disableAnimatedInsets", BIND_FN(disableAnimatedInsets)}
         };
 
         this->setters = {
@@ -66,6 +67,7 @@ struct JSI_EXPORT UnistylesRuntime : public jsi::HostObject, UnistylesModel {
     jsi::Value setRootBackgroundColor(jsi::Runtime&, std::string);
     jsi::Value setImmersiveModeEnabled(jsi::Runtime&, std::string);
     jsi::Value getIsRtl(jsi::Runtime&, std::string);
+    jsi::Value disableAnimatedInsets(jsi::Runtime&, std::string);
 
     std::optional<jsi::Value> setThemes(jsi::Runtime&, const jsi::Value&);
 

--- a/docs/.astro/settings.json
+++ b/docs/.astro/settings.json
@@ -1,5 +1,5 @@
 {
 	"_variables": {
-		"lastUpdateCheck": 1720447718845
+		"lastUpdateCheck": 1725018017706
 	}
 }

--- a/examples/expo/src/examples/HomeScreen.tsx
+++ b/examples/expo/src/examples/HomeScreen.tsx
@@ -501,7 +501,8 @@ export const HomeScreen = () => {
                                 })
                                 .addBreakpoints(breakpoints)
                                 .addConfig({
-                                    initialTheme: 'light'
+                                    initialTheme: 'light',
+                                    disableAnimatedInsets: true
                                 })
 
                             navigation.navigate(DemoNames.Keyboard)

--- a/src/core/UnistyleRegistry.ts
+++ b/src/core/UnistyleRegistry.ts
@@ -1,6 +1,6 @@
 import type { UnistylesBridge, UnistylesConfig, UnistylesPlugin } from '../types'
 import type { UnistylesBreakpoints, UnistylesThemes } from '../global'
-import { isDev, isWeb, UnistylesError } from '../common'
+import { isAndroid, isDev, isWeb, UnistylesError } from '../common'
 import { cssMediaQueriesPlugin, normalizeWebStylesPlugin } from '../plugins'
 
 export class UnistyleRegistry {
@@ -62,6 +62,10 @@ export class UnistyleRegistry {
 
         if (isWeb && config.windowResizeDebounceTimeMs !== undefined) {
             this.unistylesBridge.setWindowResizeDebounceTimeMs(config.windowResizeDebounceTimeMs)
+        }
+
+        if (isAndroid && config.disableAnimatedInsets) {
+            this.unistylesBridge.disableAnimatedInsets()
         }
 
         return {

--- a/src/types/unistyles.ts
+++ b/src/types/unistyles.ts
@@ -32,7 +32,8 @@ export type UnistylesConfig = {
     initialTheme?: keyof UnistylesThemes,
     plugins?: Array<UnistylesPlugin>,
     experimentalCSSMediaQueries?: boolean,
-    windowResizeDebounceTimeMs?: number
+    windowResizeDebounceTimeMs?: number,
+    disableAnimatedInsets?: boolean
 }
 
 export type UnistylesBridge = {
@@ -66,6 +67,9 @@ export type UnistylesBridge = {
 
     // web only
     setWindowResizeDebounceTimeMs(timeMs: number): void
+
+    // android only
+    disableAnimatedInsets(): void
 }
 
 export type UnistylesThemeEvent = {


### PR DESCRIPTION
## Summary

Fixes #268 
and other reports about unnecessary re-renders.

From version 2.8.4 Unistyles is automatically animating bottom insets for Android. This can now be disabled with following config:

```tsx
UnistylesRegistry
  .addConfig({
    disableAnimatedInsets: true // android only
  })
```

This feature already works differently on branch 3.x but anyone can disable it without any additional effort.
