### PR TITLE
Web experimentalCSSMediaQueries: fix when value is undefined

### DIFF
--- a/src/hooks/useCSS.ts
+++ b/src/hooks/useCSS.ts
@@ -16,7 +16,7 @@ export const useCSS = <T>(stylesheet: ReactNativeStyleSheet<T>) => {
             .forEach(([_key, value]) => {
                 Object.entries(value!)
                     .forEach(([prop, val]) => {
-                        if (!val.toString().includes('@media')) {
+                        if (!val?.toString().includes('@media')) {
                             return
                         }
 


### PR DESCRIPTION
## Summary
Using experimentalCSSMediaQueries on web, if the value is undefined it will crash
<!-- Explain the motivation for this PR. Include "Fixes #<number>" if applicable. -->
