### PR TITLE
fix: syntax problem at docs/reference/variants.mdx

### DIFF
--- a/docs/src/content/docs/reference/variants.mdx
+++ b/docs/src/content/docs/reference/variants.mdx
@@ -267,7 +267,7 @@ Instead of using `enum` or `strings` with `|` , you can use `UnistylesVariants` 
 import React from 'react'
 import { useStyles, UnistylesVariants } from 'react-native-unistyles'
 
-type ComponentProps = = UnistylesVariants<typeof stylesheet>
+type ComponentProps = UnistylesVariants<typeof stylesheet>
 
 const Component: React.FunctionComponent = ({ color, size }) => {
     const { styles } = useStyles(stylesheet, {


### PR DESCRIPTION
## Summary
Hello, while reading the docs I came across what I thought was a syntax error. i wanted to fix this problem.
I don't know if I need to do the same for v3.0 branch
And thank you for this awesome library
<!-- Explain the motivation for this PR. Include "Fixes #<number>" if applicable. -->
