### PR TITLE
docs: fix wrong link href

### DIFF
--- a/docs/src/content/docs/examples/all.mdx
+++ b/docs/src/content/docs/examples/all.mdx
@@ -47,7 +47,7 @@ Collection of examples is hosted on GitHub, making it easy for you to browse, le
 #### Media queries
 
 - mq util [link](https://github.com/jpudysz/react-native-unistyles/tree/main/examples/expo/src/examples/MediaQueriesWidthHeight.tsx)
-- mixed with breakpoints [link](https://github.com/jpudysz/react-native-unistyles/tree/main/examples/expo/src/examplesMixedMediaQueries.tsx)
+- mixed with breakpoints [link](https://github.com/jpudysz/react-native-unistyles/tree/main/examples/expo/src/examples/MixedMediaQueries.tsx)
 
 #### Variants
 


### PR DESCRIPTION
## Summary
 [https://www.unistyl.es/examples/all](https://www.unistyl.es/examples/all)
There is a broken link in the “Media Queries mixed with breakpoints” section
<!-- Explain the motivation for this PR. Include "Fixes #<number>" if applicable. -->
