### PR TITLE
docs: Define React Native 0.73 as the minimum supported version

### DIFF
--- a/docs/src/content/docs/other/for-library-authors.mdx
+++ b/docs/src/content/docs/other/for-library-authors.mdx
@@ -89,7 +89,7 @@ Your UI Kit can support all React Native apps out of the box.
 ## Minimum requirements
 
 Unistyles is compatible with:
-- React Native version >=0.72
+- React Native version >=0.73
 - TypeScript >5.0
 - iOS 13.6+
 - Android 6+


### PR DESCRIPTION
## Summary

As of version 2.8.0 that includes this PR https://github.com/jpudysz/react-native-unistyles/pull/209#issuecomment-2151748931, React Native 0.73 is the minimum supported.
