### PR TITLE
docs: add missing rt parameter

### DIFF
--- a/docs/src/content/docs/v3/guides/avoiding-keyboard.mdx
+++ b/docs/src/content/docs/v3/guides/avoiding-keyboard.mdx
@@ -32,7 +32,7 @@ const KeyboardAvoidingView = () => {
     )
 }
 
-const styles = StyleSheet.create(theme => ({
+const styles = StyleSheet.create((theme, rt) => ({
     container: {
         flex: 1,
         alignItems: 'center',


### PR DESCRIPTION
## Summary

The "Avoiding Keyboard" documentation references the `rt` variable without including it in the `StyleSheet.create` function signature, causing confusion.

https://www.unistyl.es/v3/guides/avoiding-keyboard
