### PR TITLE
docs: use correct babel plugin format in example

### DIFF
--- a/docs/src/content/docs/v3/start/getting-started.mdx
+++ b/docs/src/content/docs/v3/start/getting-started.mdx
@@ -48,7 +48,7 @@ module.exports = function (api) {
     // other config
     plugins: [
         // other plugins
-        ['react-native-unistyles/plugin']
+        'react-native-unistyles/plugin'
     ]
   }
 }


### PR DESCRIPTION
## Summary

<!-- Explain the motivation for this PR. Include "Fixes #<number>" if applicable. -->
If you wrap individual plugins in the babel plugins array, it throws an error detailed here: [Plugins[0][1] must be an object, false, or undefined](https://stackoverflow.com/questions/56775030/plugins01-must-be-an-object-false-or-undefined)

This PR removes that, as even I didn't realise the issue until re-reading the docs. 