### PR TITLE
feat: make android compile

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -12,6 +12,11 @@ buildscript {
     }
 }
 
+def reactNativeArchitectures() {
+    def value = rootProject.getProperties().get("reactNativeArchitectures")
+    return value ? value.split(",") : ["armeabi-v7a", "x86", "x86_64", "arm64-v8a"]
+}
+
 apply plugin: 'com.android.library'
 apply plugin: 'org.jetbrains.kotlin.android'
 apply from: '../nitrogen/generated/android/unistyles+autolinking.gradle'
@@ -41,6 +46,7 @@ android {
         externalNativeBuild {
             cmake {
                 arguments "-DANDROID_STL=c++_shared"
+                abiFilters (*reactNativeArchitectures())
             }
         }
     }


### PR DESCRIPTION
## Summary

Fixes #373 

The issue was hard to fix because I initially thought it was related to `CMakeLists.txt`, as the compiler was throwing numerous Nitro/C++ errors.  
After many attempts, I managed to build it by simply switching the JDK to version 17 via the Android Studio GUI.  
Unfortunately, this solution only worked after running `./gradlew clean` and manually removing some cached folders.  

For Expo users building with EAS, this approach wasn't viable. We needed a way to build **Unistyles 3.0** on Android out of the box.  

After further investigation, it turned out to be a simple issue with `abiFilters` used by React Native. I had tried adjusting it multiple times before, but Android’s caching system is far too aggressive.  

This patch will be included by default in `beta.2`, but if you want to run it on `.beta1`, follow these steps:

### For Expo:
1. `rm -rf node_modules`
2. Reinstall the dependencies
3. Run `yarn expo prebuild --clean`

### For Bare React Native:
1. `rm -rf node_modules`  
2. Reinstall the dependencies
3. Remove the cached folders:  
   - `rm -rf android/.cxx`  
   - `rm -rf android/build`

<img width="414" alt="image" src="https://github.com/user-attachments/assets/9621a3e7-fa9e-46fb-b6bb-b04bdd3d6ece">

