### PR TITLE
fix: withUnistyles ref type

### DIFF
--- a/src/core/createUnistylesComponent.tsx
+++ b/src/core/createUnistylesComponent.tsx
@@ -10,5 +10,5 @@ type SupportedStyleProps = typeof SUPPORTED_STYLE_PROPS[number]
  * @deprecated Use withUnistyles instead
  */
 export const createUnistylesComponent = <TProps extends Record<string, any>, TMappings extends Partial<Omit<TProps, SupportedStyleProps>>>(Component: ComponentType<TProps>, mappings?: (theme: UnistylesTheme) => TMappings) => {
-    return withUnistyles(Component, mappings as any)
+    return withUnistyles(Component as any, mappings as any)
 }

--- a/src/core/withUnistyles/withUnistyles.tsx
+++ b/src/core/withUnistyles/withUnistyles.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, type ComponentType, forwardRef, useRef, useMemo } from 'react'
+import React, { useEffect, useState, type ComponentType, forwardRef, useRef, useMemo, type ComponentRef } from 'react'
 import type { PartialBy } from '../../types/common'
 import { UnistylesListener } from '../../web/listener'
 import { UnistylesShadowRegistry } from '../../web'
@@ -37,12 +37,12 @@ const useShadowRegistry = (style?: Record<string, any>) => {
     return classNames
 }
 
-export const withUnistyles = <TProps extends Record<string, any>, TMappings extends TProps>(Component: ComponentType<TProps>, mappings?: Mappings<TMappings>) => {
+export const withUnistyles = <TProps extends Record<string, any>, TComponent extends ComponentType<TProps>, TMappings extends TProps>(Component: TComponent, mappings?: Mappings<TMappings>) => {
     type PropsWithUnistyles = PartialBy<TProps, keyof TMappings | SupportedStyleProps> & {
         uniProps?: Mappings<TProps>
     }
 
-    return forwardRef<unknown, PropsWithUnistyles>((props, ref) => {
+    return forwardRef<ComponentRef<TComponent>, PropsWithUnistyles>((props, ref) => {
         const narrowedProps = props as PropsWithUnistyles
         const styleClassNames = useShadowRegistry(narrowedProps.style)
         const contentContainerStyleClassNames = useShadowRegistry(narrowedProps.contentContainerStyle)
@@ -74,6 +74,8 @@ export const withUnistyles = <TProps extends Record<string, any>, TMappings exte
             } : {},
         } as TProps
 
-        return <Component {...combinedProps} ref={ref} />
+        const NativeComponent = Component as ComponentType<TProps>
+
+        return <NativeComponent {...combinedProps} ref={ref} />
     })
 }


### PR DESCRIPTION
## Summary

Correctly infer ref type when using `withUnistyles`
