### PR TITLE
feat: stop processing unistyle in host object

### DIFF
--- a/cxx/core/HostStyle.h
+++ b/cxx/core/HostStyle.h
@@ -28,6 +28,7 @@ private:
     std::shared_ptr<StyleSheet> _styleSheet;
     std::shared_ptr<HybridUnistylesRuntime> _unistylesRuntime;
     std::vector<std::pair<std::string, std::string>> _variants{};
+    std::unordered_map<std::string, jsi::Value> _styleCache{};
 };
 
 }

--- a/cxx/hybridObjects/HybridShadowRegistry.cpp
+++ b/cxx/hybridObjects/HybridShadowRegistry.cpp
@@ -57,9 +57,12 @@ jsi::Value HybridShadowRegistry::link(jsi::Runtime &rt, const jsi::Value &thisVa
             if (parsedStyleSheet.isUndefined()) {
                 parsedStyleSheet = parser.getParsedStyleSheetForScopedTheme(rt, unistyle, this->_scopedTheme.value());
             }
-            
+
             // if so we need to force update
             parser.rebuildUnistyleWithScopedTheme(rt, parsedStyleSheet, unistyleData);
+        } else {
+            // for other styles, not scoped to theme we need to compute variants value
+            parser.rebuildUnistyleWithVariants(rt, unistyleData);
         }
 
         unistylesData.emplace_back(unistyleData);

--- a/cxx/parser/Parser.h
+++ b/cxx/parser/Parser.h
@@ -23,7 +23,7 @@ struct Parser {
 
     void buildUnistyles(jsi::Runtime& rt, std::shared_ptr<StyleSheet> styleSheet);
     void parseUnistyles(jsi::Runtime& rt, std::shared_ptr<StyleSheet> styleSheet);
-    void rebuildUnistylesWithVariants(jsi::Runtime& rt, std::shared_ptr<StyleSheet> styleSheet, Variants& variants);
+    void rebuildUnistyleWithVariants(jsi::Runtime& rt, std::shared_ptr<core::UnistyleData> unistyleData);
     void rebuildUnistylesInDependencyMap(jsi::Runtime& rt, core::DependencyMap& dependencyMap, std::vector<std::shared_ptr<core::StyleSheet>>& styleSheets, std::optional<UnistylesNativeMiniRuntime> maybeMiniRuntime);
     void rebuildShadowLeafUpdates(jsi::Runtime& rt, core::DependencyMap& dependencyMap);
     folly::dynamic parseStylesToShadowTreeStyles(jsi::Runtime& rt, const std::vector<std::shared_ptr<UnistyleData>>& unistyles);

--- a/example/Button.tsx
+++ b/example/Button.tsx
@@ -1,0 +1,85 @@
+import { Pressable, PressableProps, Text } from "react-native";
+import { StyleSheet, UnistylesVariants } from 'react-native-unistyles'
+
+type ButtonProps = PressableProps & UnistylesVariants<typeof styles> & {
+    style?: any;
+    children?: React.ReactNode;
+    disabled?: boolean;
+}
+
+export const Button: React.FunctionComponent<ButtonProps> = ({
+    children,
+    variant,
+    disabled = false,
+    ...props
+}: ButtonProps) => {
+    styles.useVariants({
+        variant,
+        disabled,
+    });
+
+    return (
+        <Pressable style={() => styles.button} {...props}>
+            <Text style={styles.text}>{children}</Text>
+        </Pressable>
+    );
+}
+
+const styles = StyleSheet.create((theme) => {
+    return {
+        button: {
+            flexDirection: "row",
+            alignItems: "center",
+            justifyContent: "center",
+            gap: theme.gap(1),
+            borderRadius: theme.gap(1),
+            paddingVertical: theme.gap(1),
+            variants: {
+                variant: {
+                    default: {
+                        backgroundColor: theme.colors.accent,
+                    },
+                    destructive: {
+                        backgroundColor: 'red',
+                    },
+                    outline: {
+                        backgroundColor: 'white'
+                    },
+                    link: {
+                        backgroundColor: theme.colors.accent,
+                        textDecorationLine: "underline",
+                    },
+                },
+                size: {
+                    default: {
+                        height: theme.gap(5),
+                        paddingHorizontal: 16,
+                    }
+                },
+                disabled: {
+                    true: {
+                        opacity: 0.5,
+                        pointerEvents: "none",
+                    },
+                }
+            },
+        },
+        text: {
+            fontSize: 14,
+            fontWeight: "500",
+            variants: {
+                variant: {
+                    destructive: {
+                        color: 'white'
+                    },
+                    outline: {
+                        color: 'gray'
+                    },
+                    link: {
+                        color: 'white'
+                    },
+                },
+            },
+        },
+    };
+});

--- a/src/components/native/Pressable.native.tsx
+++ b/src/components/native/Pressable.native.tsx
@@ -18,9 +18,12 @@ export const Pressable = forwardRef<View, PressableProps>(({ variants, style, ..
                 const unistyles = typeof style === 'function'
                     ? style({ pressed: false })
                     : style
+                const styles = Array.isArray(unistyles)
+                    ? unistyles
+                    : [unistyles]
 
                 // @ts-expect-error - this is hidden from TS
-                UnistylesShadowRegistry.add(ref, unistyles)
+                UnistylesShadowRegistry.add(ref, styles)
 
                 storedRef.current = ref
 


### PR DESCRIPTION
## Summary

Fixes #382  

Initially, we processed `variants` from `useVariants` in the Host Object of `StyleSheet`. Unfortunately, this was a mistake, as we shared a single `StyleSheet` instance across all components. This issue was not immediately apparent, but when one component re-rendered, it caused other (shared) styles in the single `StyleSheet` to update as well.  

This PR removes all parsing from the shared instance and moves it to the `ShadowTree`. As a bonus, I’ve added a small cache layer for getter of `styles`, which should improve performance since we no longer need to parse styles repeatedly.  