### PR TITLE
feat: pressable nested variants

### DIFF
--- a/src/components/native/Pressable.native.tsx
+++ b/src/components/native/Pressable.native.tsx
@@ -22,16 +22,16 @@ export const Pressable = forwardRef<View, PressableProps>(({ variants, style, ..
                     ? unistyles
                     : [unistyles]
 
+                UnistylesShadowRegistry.selectVariants(variants)
                 // @ts-expect-error - this is hidden from TS
                 UnistylesShadowRegistry.add(ref, styles)
+                UnistylesShadowRegistry.selectVariants(undefined)
 
                 storedRef.current = ref
 
                 return passForwardedRef(props, ref, forwardedRef)
             }}
             style={state => {
-                UnistylesShadowRegistry.selectVariants(variants)
-
                 const unistyles = typeof style === 'function'
                     ? style(state)
                     : style
@@ -39,14 +39,18 @@ export const Pressable = forwardRef<View, PressableProps>(({ variants, style, ..
                     ? unistyles
                     : [unistyles]
 
-                if (storedRef.current) {
-                    // @ts-expect-error - this is hidden from TS
-                    UnistylesShadowRegistry.remove(storedRef.current)
-                    // @ts-expect-error - this is hidden from TS
-                    UnistylesShadowRegistry.add(storedRef.current, styles)
+                if (!storedRef.current) {
+                    return unistyles
                 }
 
-                UnistylesShadowRegistry.selectVariants(undefined)
+                if (state.pressed) {
+                    UnistylesShadowRegistry.selectVariants(variants)
+                }
+
+                // @ts-expect-error - this is hidden from TS
+                UnistylesShadowRegistry.remove(storedRef.current)
+                // @ts-expect-error - this is hidden from TS
+                UnistylesShadowRegistry.add(storedRef.current, styles)
 
                 return unistyles
             }}


### PR DESCRIPTION
## Summary

Addresses issues reported on Discord.  
For nested variants, `Pressable` was unable to resolve variants in the correct order.

Repro: https://github.com/akuul/unistyles-repo-repro

After:

https://github.com/user-attachments/assets/d195c565-67be-4ff5-ac73-b5cf82be3cfc


