### PR TITLE
feat: withUnistyles - accept variants before any native event

### DIFF
--- a/cxx/core/HostStyle.cpp
+++ b/cxx/core/HostStyle.cpp
@@ -32,7 +32,12 @@ jsi::Value HostStyle::get(jsi::Runtime& rt, const jsi::PropNameID& propNameId) {
             return jsi::Value(rt, this->_styleCache[propertyName]);
         }
         
-        this->_styleCache[propertyName] = valueFromUnistyle(rt, this->_unistylesRuntime, this->_styleSheet->unistyles[propertyName]);
+        this->_styleCache[propertyName] = valueFromUnistyle(
+            rt,
+            this->_unistylesRuntime,
+            this->_styleSheet->unistyles[propertyName],
+            this->_variants
+        );
         
         return jsi::Value(rt, this->_styleCache[propertyName]);
     }

--- a/cxx/core/UnistyleWrapper.h
+++ b/cxx/core/UnistyleWrapper.h
@@ -116,7 +116,7 @@ inline static std::vector<Unistyle::Shared> unistyleFromValue(jsi::Runtime& rt, 
     return unistyles;
 }
 
-inline static jsi::Value valueFromUnistyle(jsi::Runtime& rt, std::shared_ptr<HybridUnistylesRuntime> unistylesRuntime, Unistyle::Shared unistyle) {
+inline static jsi::Value valueFromUnistyle(jsi::Runtime& rt, std::shared_ptr<HybridUnistylesRuntime> unistylesRuntime, Unistyle::Shared unistyle, Variants& variants) {
     auto wrappedUnistyle = std::make_shared<UnistyleWrapper>(unistyle);
 
     if (unistyle->type == UnistyleType::Object) {
@@ -128,7 +128,7 @@ inline static jsi::Value valueFromUnistyle(jsi::Runtime& rt, std::shared_ptr<Hyb
         helpers::defineHiddenProperty(rt, obj, helpers::STYLE_DEPENDENCIES.c_str(), helpers::dependenciesToJSIArray(rt, unistyle->dependencies));
         helpers::mergeJSIObjects(rt, obj, unistyle->parsedStyle.value());
 
-        obj.setProperty(rt, "__proto__", generateUnistylesPrototype(rt, unistylesRuntime, unistyle, std::nullopt, std::nullopt));
+        obj.setProperty(rt, "__proto__", generateUnistylesPrototype(rt, unistylesRuntime, unistyle, variants, std::nullopt));
 
         return obj;
     }

--- a/src/core/withUnistyles/withUnistyles.native.tsx
+++ b/src/core/withUnistyles/withUnistyles.native.tsx
@@ -37,7 +37,8 @@ export const withUnistyles = <TComponent, TMappings extends GenericComponentProp
 
                     stylesRef.current = {
                         ...stylesRef.current,
-                        [propName]: narrowedProps[propName]
+                        // @ts-expect-error - this is hidden from TS
+                        [propName]: props[propName].__proto__?.getStyle?.() || props[propName]
                     }
                 }
             })


### PR DESCRIPTION
## Summary

Issue was reported on Discord.  
Wrapping a component with `withUnistyles` that uses `variants` had no effect because the Unistyle core was not attaching variants to nodes outside of the `ShadowRegistry`. This PR resolves the issue. 
