### PR TITLE
feat: text nested variants

### DIFF
--- a/cxx/hybridObjects/HybridShadowRegistry.cpp
+++ b/cxx/hybridObjects/HybridShadowRegistry.cpp
@@ -132,3 +132,12 @@ jsi::Value HybridShadowRegistry::getScopedTheme(jsi::Runtime &rt, const jsi::Val
         ? jsi::String::createFromUtf8(rt, maybeScopedTheme.value())
         : jsi::Value::undefined();
 }
+
+jsi::Value HybridShadowRegistry::getVariants(jsi::Runtime &rt, const jsi::Value &thisValue, const jsi::Value *args, size_t count) {
+    auto& registry = core::UnistylesRegistry::get();
+    auto maybeScopedVariants = registry.getScopedVariants();
+    
+    return maybeScopedVariants.size() > 0
+        ? helpers::variantsToValue(rt, maybeScopedVariants)
+        : jsi::Value::undefined();
+}

--- a/cxx/hybridObjects/HybridShadowRegistry.h
+++ b/cxx/hybridObjects/HybridShadowRegistry.h
@@ -32,16 +32,21 @@ struct HybridShadowRegistry: public HybridUnistylesShadowRegistrySpec {
                             const jsi::Value& thisValue,
                             const jsi::Value* args,
                             size_t count);
+    jsi::Value getVariants(jsi::Runtime& rt,
+                            const jsi::Value& thisValue,
+                            const jsi::Value* args,
+                            size_t count);
 
     void loadHybridMethods() override {
         HybridUnistylesShadowRegistrySpec::loadHybridMethods();
 
         registerHybrids(this, [](Prototype& prototype) {
             prototype.registerRawHybridMethod("link", 2, &HybridShadowRegistry::link);
-            prototype.registerRawHybridMethod("unlink", 2, &HybridShadowRegistry::unlink);
-            prototype.registerRawHybridMethod("selectVariants", 2, &HybridShadowRegistry::selectVariants);
-            prototype.registerRawHybridMethod("setScopedTheme", 2, &HybridShadowRegistry::setScopedTheme);
-            prototype.registerRawHybridMethod("getScopedTheme", 2, &HybridShadowRegistry::getScopedTheme);
+            prototype.registerRawHybridMethod("unlink", 1, &HybridShadowRegistry::unlink);
+            prototype.registerRawHybridMethod("selectVariants", 1, &HybridShadowRegistry::selectVariants);
+            prototype.registerRawHybridMethod("setScopedTheme", 1, &HybridShadowRegistry::setScopedTheme);
+            prototype.registerRawHybridMethod("getScopedTheme", 0, &HybridShadowRegistry::getScopedTheme);
+            prototype.registerRawHybridMethod("getVariants", 0, &HybridShadowRegistry::getVariants);
         });
     };
 

--- a/src/components/Variants.tsx
+++ b/src/components/Variants.tsx
@@ -15,10 +15,11 @@ const Apply: React.FunctionComponent<VariantProps> = ({ variants }) => {
     return null
 }
 export const Variants: React.FunctionComponent<React.PropsWithChildren<VariantProps>> = ({ variants, children }) => {
+    const previousScopedVariants = UnistylesShadowRegistry.getVariants()
     const mappedChildren = [
         <Apply key='add' variants={variants} />,
         children,
-        <Apply key='remove' />
+        <Apply key='remove' variants={previousScopedVariants} />
     ]
 
     return (

--- a/src/components/native/Pressable.native.tsx
+++ b/src/components/native/Pressable.native.tsx
@@ -22,10 +22,8 @@ export const Pressable = forwardRef<View, PressableProps>(({ variants, style, ..
                     ? unistyles
                     : [unistyles]
 
-                UnistylesShadowRegistry.selectVariants(variants)
                 // @ts-expect-error - this is hidden from TS
                 UnistylesShadowRegistry.add(ref, styles)
-                UnistylesShadowRegistry.selectVariants(undefined)
 
                 storedRef.current = ref
 


### PR DESCRIPTION
## Summary

Fixes an issue reported on Discord.  
If there are two text nodes with a parent <-> child relationship, there was a bug where the child's variants would override the parent's variants. This PR fixes that by ensuring variants are rolled out from the child to the parent, so every node now has the correct variant attached. It also supports cases where React Native `Text` nodes inherit parent styles, similar to regular React Native behavior.

For:

```tsx
<React.Fragment>
      <ThemedText type="title">
        Parent
        <ThemedText>
          Amother ThemedText
        </ThemedText>
      </ThemedText>
      <ThemedText type="title">
        Parent
        <Text>
          RN Text
        </Text>
      </ThemedText>
</React.Fragment>
```

We should get following result:

![RocketSim_Screenshot_iPhone_16_Pro_Max_6 9_2024-12-15_15 38 16](https://github.com/user-attachments/assets/d12c5d0b-1d49-44ed-b439-66f61d1ab251)

Requires regression testing before merging for #433 