### PR TITLE
Set the landing page language to English

### DIFF
--- a/docs/src/pages/index.astro
+++ b/docs/src/pages/index.astro
@@ -16,7 +16,7 @@ const openGraph = {
 ---
 
 <!doctype html>
-<html lang="pl">
+<html lang="en">
 	<head>
         <SEO
             charset="UTF-8"


### PR DESCRIPTION
## Summary

When I go to https://www.unistyl.es/, my browser keeps offering to translate the page from Polish to English. It appears that the documentation is in English, so this PR sets the HTML language to English