### PR TITLE
feat: add includes babel plugin option for node module whitelist

### DIFF
--- a/plugin/import.js
+++ b/plugin/import.js
@@ -63,7 +63,19 @@ function addUnistylesImport(t, path, state) {
     nodesToRemove.forEach(node => path.node.body.splice(path.node.body.indexOf(node), 1))
 }
 
-const isInsideNodeModules = state => state.file.opts.filename.includes('node_modules')
+const isInsideNodeModules = (state) => {
+    const isNodeModule = state.file.opts.filename.includes('node_modules');
+  
+    if (Array.isArray(state.opts.includes) && isNodeModule) {
+      const isIncludedNodeModule = state.opts.includes.some((pkg) =>
+        state.file.opts.filename.includes(`node_modules/${pkg}`),
+      );
+  
+      return !isIncludedNodeModule;
+    }
+  
+    return isNodeModule;
+};
 
 module.exports = {
     isInsideNodeModules,


### PR DESCRIPTION
## Summary

Suggestion for babel plugin option for node module package whitelist

## Problem

I'm building my `ui-kit` npm ui library powered by `unistyles v3-beta.4`

When `ui-kit` is added as node modules dependency to my app, current version unistyle babel plugin is skipping transforming. 

So I'm getting errors below even though `Stylesheet.configure` is done. 

<img width="627" alt="Screenshot 2024-12-26 at 4 29 33 PM" src="https://github.com/user-attachments/assets/1bb7ac50-8a43-4473-a37d-a6c0e8107941" />

## Suggestion

How about adding `includes` option to whitelist node modules package that should be transformed using unistyles?

```js
[
      // add custom packages to be transformed
      'react-native-unistyles/plugin', { includes: ['@jeongshin/ui-kit'] }
 ],
```

It works fine when I tested on my local project. 

Thanks for great great library. 🙌
