### PR TITLE
Update Hide and Show documentation in breakpoints.mdx

### DIFF
--- a/docs/src/content/docs/v3/references/breakpoints.mdx
+++ b/docs/src/content/docs/v3/references/breakpoints.mdx
@@ -145,10 +145,10 @@ import { Display, Hide, mq } from 'react-native-unistyles'
 
 const MyComponent = () => {
     return (
-        <Display mq={mq.width(0, 400)}>
+        <Display mq={mq.only.width(0, 400)}>
             <Text>This text is visible on small devices</Text>
         </Display>
-        <Hide mq={mq.width(400)}>
+        <Hide mq={mq.only.width(400)}>
             <Text>This text is hidden on big devices</Text>
         </Hide>
     )


### PR DESCRIPTION
## Summary

Currently, the code as suggested does not work.

```
Type '{ and: { height(hMin?: Nullable<MQValue> | undefined, hMax?: MQValue | undefined): symbol; }; }' is not assignable to type 'symbol'.ts(2322)
Hide.d.ts(3, 5): The expected type comes from property 'mq' which is declared here on type 'IntrinsicAttributes & { mq: symbol; } & { children?: ReactNode; }'
```

Additionally, at runtime, I receive this error:

```
Received invalid mq: [object Object] Error Component Stack
```

This updates the documentation to use the correct methods.