### PR TITLE
docs: rename object to match official parameter name + simplify example

### DIFF
--- a/docs/src/content/docs/v3/other/babel-plugin.mdx
+++ b/docs/src/content/docs/v3/other/babel-plugin.mdx
@@ -192,43 +192,9 @@ The Babel plugin comes with a few additional options to extend its usage.
 
 If you use ui-kit components, you can configure the Babel plugin to process them.
 
-```js title="babel.config.js"
-/** @type {import('react-native-unistyles/plugin').UnistylesPluginOptions} */
-const unistylesPluginConfig = {
-    autoProcessImports: ['@lib/ui-kit'],
-}
-
-module.exports = function (api) {
-    api.cache(true)
-
-    return {
-        plugins: [
-            ['react-native-unistyles/plugin', unistylesPluginConfig]
-        ]
-    }
-}
-```
-
 ### `autoProcessPaths`
 
 Similar to `autoProcessImports`, you can configure the Babel plugin to process paths.
-
-```js title="babel.config.js"
-/** @type {import('react-native-unistyles/plugin').UnistylesPluginOptions} */
-const unistylesPluginConfig = {
-    autoProcessPaths: ['external-library/components'],
-}
-
-module.exports = function (api) {
-    api.cache(true)
-
-    return {
-        plugins: [
-            ['react-native-unistyles/plugin', unistylesPluginConfig]
-        ]
-    }
-}
-```
 
 ### `debug`
 
@@ -236,7 +202,9 @@ In order to debug issues with the Babel plugin you can enable the `debug` boolea
 
 ```js title="babel.config.js"
 /** @type {import('react-native-unistyles/plugin').UnistylesPluginOptions} */
-const unistylesPluginConfig = {
+const unistylesPluginOptions = {
+    autoProcessImports: ['@lib/ui-kit'],
+    autoProcessPaths: ['external-library/components'],
     debug: true,
 }
 
@@ -245,7 +213,7 @@ module.exports = function (api) {
 
     return {
         plugins: [
-            ['react-native-unistyles/plugin', unistylesPluginConfig]
+            ['react-native-unistyles/plugin', unistylesPluginOptions]
         ]
     }
 }

--- a/example/babel.config.js
+++ b/example/babel.config.js
@@ -2,7 +2,7 @@ const path = require('path')
 const pak = require('../package.json')
 
 /** @type {import('../plugin').UnistylesPluginOptions} */
-const unistylesPluginConfig = {
+const unistylesPluginOptions = {
     debug: true,
     isLocal: true,
     autoProcessImports: ['@lib/theme', './st'],
@@ -16,7 +16,7 @@ module.exports = api => {
         plugins: [
             [
                 path.join(__dirname, '../plugin'),
-                unistylesPluginConfig
+                unistylesPluginOptions
             ],
             [
                 'module-resolver',


### PR DESCRIPTION
## Summary

I wasn't totally satisfied ahah

- Rename object to match official babel parameter name + interface
- Simplify example to only show one babel.config.js to make it easier to read
