### PR TITLE
fix: Update Babel plugin to process external modules

### DIFF
--- a/plugin/import.js
+++ b/plugin/import.js
@@ -44,7 +44,9 @@ function addUnistylesImport(t, path, state) {
 }
 
 const isInsideNodeModules = state => {
-    return state.file.opts.filename.includes('node_modules') && !state.file.opts.filename.includes(state.opts.autoProcessImports ?? [])
+    return state.file.opts.filename.includes('node_modules') && !(state.opts.autoProcessImports ?? []).some(importName => {
+        return state.file.opts.filename.includes(importName)
+    })
 }
 
 module.exports = {

--- a/plugin/import.js
+++ b/plugin/import.js
@@ -43,7 +43,9 @@ function addUnistylesImport(t, path, state) {
     nodesToRemove.forEach(node => path.node.body.splice(path.node.body.indexOf(node), 1))
 }
 
-const isInsideNodeModules = state => state.file.opts.filename.includes('node_modules')
+const isInsideNodeModules = state => {
+    return state.file.opts.filename.includes('node_modules') && !state.file.opts.filename.includes(state.opts.autoProcessImports ?? [])
+}
 
 module.exports = {
     isInsideNodeModules,


### PR DESCRIPTION
## Summary

This PR adds a quick fix to help process external modules. Seems it was previously done in https://github.com/jpudysz/react-native-unistyles/pull/468, and after https://github.com/jpudysz/react-native-unistyles/issues/436#issuecomment-2587699711 was introduced, it doesn't seem to work in my case.

With this configuration (and the fix from this PR):

```javascript
[
  'react-native-unistyles/plugin',
  {
    autoProcessImports: ['@grapp/stacks'],
    debug: true,
  },
],
```

all files in the external library will be processed correctly using the Unistyles Babel plugin.

If you skip this, you'll see the same error that others have mentioned:

```
Unistyles is not initialized correctly. Please add the Babel plugin to your Babel config.
```

To check this out, you can easily reproduce the issue. Just install the external library (like `@grapp/stacks`), open the main `index.ts` file in that library (for instance, located at `node_modules/@grapp/stacks/index.ts`), and add this code:

```tsx
import { StyleSheet } from 'react-native-unistyles';

export const Box = () => {
  return null;
};

const styles = StyleSheet.create({
  root: {
    variants: {
      alignItems: {
        center: {
          alignItems: 'center',
        },
      },
    },
  },
});
```