### PR TITLE
Fix/rename secrets

### DIFF
--- a/cxx/core/HashGenerator.cpp
+++ b/cxx/core/HashGenerator.cpp
@@ -17,7 +17,7 @@ std::string HashGenerator::generateHash(const std::string& input) {
     std::stringstream ss;
     ss << std::hex << std::setfill('0') << std::setw(8) << (combinedHash & 0xFFFFFFFF);
 
-    return "unistyles-" + ss.str();
+    return "unistyles_" + ss.str();
 }
 
 }

--- a/cxx/core/UnistyleWrapper.h
+++ b/cxx/core/UnistyleWrapper.h
@@ -35,7 +35,7 @@ inline static Unistyle::Shared unistyleFromStaticStyleSheet(jsi::Runtime& rt, js
 
 inline static std::vector<std::string> getUnistylesHashKeys(jsi::Runtime& rt, jsi::Object& object) {
     std::vector<std::string> matchingKeys{};
-    const std::string prefix = "unistyles-";
+    const std::string prefix = "unistyles_";
 
     auto propertyNames = object.getPropertyNames(rt);
     size_t length = propertyNames.length(rt);
@@ -82,13 +82,13 @@ inline static std::vector<Unistyle::Shared> unistylesFromNonExistentNativeState(
 
 You likely altered unistyle hash key and we're not able to recover C++ state attached to this node.)");
     }
-    
+
     // someone merged unistyles, and will be warned in JS
     // the best we can do is to return first unistyle
     if (unistyles.size() > 1) {
         return {unistyles.at(0)};
     }
-    
+
     return unistyles;
 }
 
@@ -137,7 +137,7 @@ inline static jsi::Value objectFromUnistyle(jsi::Runtime& rt, std::shared_ptr<Hy
     auto parsedArguments = arguments.has_value()
         ? helpers::parseDynamicFunctionArguments(rt, arguments.value())
         : std::optional<std::vector<folly::dynamic>>{};
-    
+
     if (arguments.has_value()) {
         // this is required for HybridShadowRegistry::link
         helpers::defineHiddenProperty(rt, secrets, helpers::ARGUMENTS.c_str(), arguments.value());
@@ -148,7 +148,7 @@ inline static jsi::Value objectFromUnistyle(jsi::Runtime& rt, std::shared_ptr<Hy
 
     // this is required for withUnistyles
     helpers::defineHiddenProperty(rt, secrets, helpers::STYLE_DEPENDENCIES.c_str(), helpers::dependenciesToJSIArray(rt, unistyle->dependencies));
-    
+
     // this is required for withUnistyles
     auto hostFn = jsi::Function::createFromHostFunction(
         rt,
@@ -160,7 +160,7 @@ inline static jsi::Value objectFromUnistyle(jsi::Runtime& rt, std::shared_ptr<Hy
 
         return jsi::Value(rt, unistyle->parsedStyle.value()).asObject(rt);
     });
-    
+
     helpers::defineHiddenProperty(rt, secrets, helpers::GET_STYLES.c_str(), std::move(hostFn));
 
     obj.setProperty(rt, unistyleID, secrets);

--- a/docs/src/content/docs/v3/guides/server-side-rendering.mdx
+++ b/docs/src/content/docs/v3/guides/server-side-rendering.mdx
@@ -65,3 +65,9 @@ The `unistyles.ts` file is where Unistyles is configured. For more details, refe
 
 With this setup, we will ensure that Unistyles is initialized correctly and injects CSS on the server side.
 </Seo>
+
+### Config (Optional)
+
+`useServerUnistyles` accepts an optional config object:
+
+- **`includeRNWStyles`** – a boolean that enables or disables injecting React Native Web default CSS styles. Defaults to `true`.

--- a/docs/src/content/docs/v3/references/web-styles.mdx
+++ b/docs/src/content/docs/v3/references/web-styles.mdx
@@ -42,18 +42,18 @@ const styles = StyleSheet.create({
 This results in the following CSS output:
 
 ```css
-.unistyles-1u0egm6 {
+.unistyles_1u0egm6 {
   flex: 1;
 }
 
 @media (min-width: 0px) {
-  .unistyles-kaoph5 {
+  .unistyles_kaoph5 {
     font-size: 32px;
   }
 }
 
 @media (min-width: 1200px) {
-  .unistyles-kaoph5 {
+  .unistyles_kaoph5 {
     font-size: 40px;
   }
 }
@@ -77,7 +77,7 @@ const styles = StyleSheet.create(theme => ({
 The generated CSS might look like:
 
 ```css
-.unistyles-1u0egm6 {
+.unistyles_1u0egm6 {
   flex: 1;
   background-color: #000;
 }
@@ -92,7 +92,7 @@ UnistylesRuntime.setTheme('light')
 The CSS will automatically update to:
 
 ```css
-.unistyles-1u0egm6 {
+.unistyles_1u0egm6 {
   flex: 1;
   background-color: #fff;
 }

--- a/src/components/native/Pressable.native.tsx
+++ b/src/components/native/Pressable.native.tsx
@@ -11,7 +11,7 @@ type PressableProps = Props & {
 const getStyles = (styleProps: Record<string, any> = {}) => {
     const unistyleKey = Object
         .keys(styleProps)
-        .find(key => key.startsWith('unistyles-'))
+        .find(key => key.startsWith('unistyles_'))
 
     if (!unistyleKey) {
         return styleProps

--- a/src/core/warn.ts
+++ b/src/core/warn.ts
@@ -4,7 +4,7 @@ export const maybeWarnAboutMultipleUnistyles = (style: ViewStyle, displayName = 
     if (__DEV__ && style && !Array.isArray(style)) {
         const unistylesKeys = Object
             .keys(style)
-            .filter(key => key.startsWith('unistyles-'))
+            .filter(key => key.startsWith('unistyles_'))
 
         if (unistylesKeys.length > 1) {
             console.warn(`Unistyles: we detected style object with ${unistylesKeys.length} unistyles styles. This might cause no updates or unpredictable behavior. Please check style prop for "${displayName}" and use array syntax instead of object syntax.`)

--- a/src/core/withUnistyles/withUnistyles.native.tsx
+++ b/src/core/withUnistyles/withUnistyles.native.tsx
@@ -19,7 +19,7 @@ export const withUnistyles = <TComponent, TMappings extends GenericComponentProp
     const getSecrets = (styleProps: Record<string, any> = {}): { uni__getStyles(): any, uni__dependencies: Array<UnistyleDependency> } => {
         const unistyleKey = Object
             .keys(styleProps)
-            .find(key => key.startsWith('unistyles-'))
+            .find(key => key.startsWith('unistyles_'))
 
         return unistyleKey
             ? styleProps[unistyleKey]

--- a/src/web/convert/index.ts
+++ b/src/web/convert/index.ts
@@ -17,7 +17,7 @@ export const convertUnistyles = (value: UnistylesValues) => {
         ...value._web
     }).flatMap(([unistylesKey, unistylesValue]) => {
         // Keys to omit
-        if (['_classNames', '_web', 'variants', 'compoundVariants', 'uni__dependencies', '__unistyles-secrets__'].includes(unistylesKey) || unistylesKey.startsWith('variant-')) {
+        if (['_classNames', '_web', 'variants', 'compoundVariants', 'uni__dependencies'].includes(unistylesKey) || unistylesKey.startsWith('unistyles_')) {
             return []
         }
 

--- a/src/web/utils/common.ts
+++ b/src/web/utils/common.ts
@@ -65,5 +65,5 @@ const cyrb53 = (data: string, seed = 0) => {
 export const generateHash = (value: any) => {
     const serialized = serialize(value)
 
-    return `unistyles-${cyrb53(serialized).toString(36)}`
+    return `unistyles_${cyrb53(serialized).toString(36)}`
 }

--- a/src/web/utils/unistyle.ts
+++ b/src/web/utils/unistyle.ts
@@ -27,9 +27,9 @@ export const assignSecrets = <T>(object: T, secrets: UnistyleSecrets) => {
     const secretsId = Math.random().toString(36).slice(8)
 
     // @ts-expect-error assign hidden secrets
-    object[`unistyles-${secretsId}`] = {}
+    object[`unistyles_${secretsId}`] = {}
     // @ts-expect-error assign hidden secrets
-    Object.defineProperties(object[`unistyles-${secretsId}`], reduceObject(secrets, secret => ({
+    Object.defineProperties(object[`unistyles_${secretsId}`], reduceObject(secrets, secret => ({
         value: secret,
         enumerable: false,
         configurable: true
@@ -43,7 +43,7 @@ export const extractSecrets = (object: any) => {
         return undefined
     }
 
-    const [, secrets] = Object.entries(object).find(([key]) => key.startsWith('unistyles-')) ?? []
+    const [, secrets] = Object.entries(object).find(([key]) => key.startsWith('unistyles_')) ?? []
 
     if (!secrets) {
         return undefined


### PR DESCRIPTION
## Summary

Rename secrets from `unistyles-{X}` to `unistyles_{X}` to prevent warnings from react native

![image](https://github.com/user-attachments/assets/94e92896-01ac-4b5f-8a60-abd5da9c665b)
