### PR TITLE
Improve expo-router instruction with typescript entry file

### DIFF
--- a/docs/src/content/docs/v3/guides/expo-router.mdx
+++ b/docs/src/content/docs/v3/guides/expo-router.mdx
@@ -24,13 +24,13 @@ This combination may cause some issues. To prevent that you need to modify your 
 ```diff lang="json" title="package.json"
 {
 -   "main": "expo-router/entry"
-+   "main": "index.js"
++   "main": "index.ts"
 }
 ```
 
-Then, create `index.js` file with following content:
+Then, create `index.ts` file with following content:
 
-```js title="index.js"
+```js title="index.ts"
 import 'expo-router/entry'
 import './unistyles' // <-- file that initializes Unistyles
 ```


### PR DESCRIPTION
## Summary


I have noticed that the entry file can be a typescript file too. It might be confusing to readers if the doc only mention `.js` (which was my case).

Hope this helps!
