### PR TITLE
fix: package.json exports warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     ".": {
       "types": "./lib/typescript/src/index.d.ts",
       "module": "./lib/module/index.js",
-      "react-native": "./src/index",
+      "react-native": "./src/index.ts",
       "default": "./lib/commonjs/index.js"
     },
     "./components/native/*": {
@@ -39,7 +39,7 @@
     "./server": {
       "types": "./lib/typescript/src/server/index.d.ts",
       "module": "./lib/module/server/index.js",
-      "react-native": "./src/server",
+      "react-native": "./src/server.ts",
       "default": "./lib/commonjs/server/index.js"
     }
   },


### PR DESCRIPTION
## Summary

Fix the following issue on nightly

```
The package node_modules/react-native-unistyles contains an invalid package.json configuration. Consider raising this issue with the package maintainer(s).
Reason: The resolution for "node_modules/react-native-unistyles" defined in "exports" is node_modules/react-native-unistyles/src/index, however this file does not exist. Falling back to file-based resolution.
```