### PR TITLE
feat: parse colors in arrays

### DIFF
--- a/expo-example/unistyles.ts
+++ b/expo-example/unistyles.ts
@@ -62,7 +62,8 @@ declare module 'react-native-unistyles' {
 
 StyleSheet.configure({
     settings: {
-        adaptiveThemes: true
+        adaptiveThemes: false,
+        initialTheme: 'light'
     },
     breakpoints,
     themes: {

--- a/expo-example/unistyles.ts
+++ b/expo-example/unistyles.ts
@@ -62,8 +62,7 @@ declare module 'react-native-unistyles' {
 
 StyleSheet.configure({
     settings: {
-        adaptiveThemes: false,
-        initialTheme: 'light'
+        adaptiveThemes: true
     },
     breakpoints,
     themes: {


### PR DESCRIPTION
## Summary

Fixes #609 

Native Views expect colors to be represented as `int`. In the current implementation we were missing parsing objects in arrays eg. for `boxShadow`.

Example:
```tsx
boxShadow: [
    {
      offsetX: 5,
      offsetY: 5,
      blurRadius: 5,
      spreadDistance: 0,
      color: "red",
    }
]
```

was passed to ShadowTree as-is causing crash on Android and no shadow on iOS.

Right now it will look like this:

```tsx
boxShadow: [
   {
     offsetX: 5,
     offsetY: 5,
     blurRadius: 5,
     spreadDistance: 0,
     color: 2312311
   }
]
```