### PR TITLE
feat: improve layout animations

### DIFF
--- a/cxx/core/UnistylesMountHook.cpp
+++ b/cxx/core/UnistylesMountHook.cpp
@@ -22,7 +22,7 @@ void core::UnistylesMountHook::shadowTreeDidMount(RootShadowNode::Shared const &
     // one more time merge Unistyles changes
     auto& registry = core::UnistylesRegistry::get();
 
-    if (!registry.trafficController.shouldStop()) {
-        shadow::ShadowTreeManager::updateShadowTree(this->_uiManager->getShadowTreeRegistry());
+    if (registry.trafficController.shouldStop()) {
+        registry.trafficController.resumeUnistylesTraffic();
     }
 }

--- a/cxx/core/UnistylesMountHook.h
+++ b/cxx/core/UnistylesMountHook.h
@@ -3,15 +3,13 @@
 #include <react/renderer/uimanager/UIManager.h>
 #include <react/renderer/uimanager/UIManagerMountHook.h>
 #include "ShadowTreeManager.h"
-#include "HybridUnistylesRuntime.h"
 
 namespace margelo::nitro::unistyles::core {
 
 using namespace facebook::react;
 
 struct UnistylesMountHook : public UIManagerMountHook {
-    UnistylesMountHook(std::shared_ptr<UIManager> uiManager, std::shared_ptr<HybridUnistylesRuntime> unistylesRuntime)
-        : _uiManager{uiManager}, _unistylesRuntime{unistylesRuntime} {
+    UnistylesMountHook(std::shared_ptr<UIManager> uiManager): _uiManager{uiManager} {
         _uiManager->registerMountHook(*this);
     }
 
@@ -21,7 +19,6 @@ struct UnistylesMountHook : public UIManagerMountHook {
 
 private:
     std::shared_ptr<UIManager> _uiManager;
-    std::shared_ptr<HybridUnistylesRuntime> _unistylesRuntime;
 };
 
 }

--- a/cxx/hybridObjects/HybridStyleSheet.cpp
+++ b/cxx/hybridObjects/HybridStyleSheet.cpp
@@ -261,7 +261,7 @@ void HybridStyleSheet::registerHooks(jsi::Runtime& rt) {
     core::UnistylesRegistry::get().trafficController.restore();
 
     this->_unistylesCommitHook = std::make_shared<core::UnistylesCommitHook>(this->_uiManager);
-    this->_unistylesMountHook = std::make_shared<core::UnistylesMountHook>(this->_uiManager, this->_unistylesRuntime);
+    this->_unistylesMountHook = std::make_shared<core::UnistylesMountHook>(this->_uiManager);
 }
 
 void HybridStyleSheet::onPlatformDependenciesChange(std::vector<UnistyleDependency> dependencies) {


### PR DESCRIPTION
## Summary

Remove additional shadow tree cloning in Mount hook. 
During the first beta it was necessary due to a lot of hacks and edge cases.
Now Unistyles runs smoothly without it and receives predictable behaviour.

Should also speed things up in benchmarks. Should be tested by wider group of testes.

Fixes #622 
