### PR TITLE
fix: simplify withUnistyles types

### DIFF
--- a/src/core/withUnistyles/withUnistyles.native.tsx
+++ b/src/core/withUnistyles/withUnistyles.native.tsx
@@ -1,11 +1,10 @@
 import React, { forwardRef, useEffect, type ComponentType, useRef } from 'react'
 import { type UnistyleDependency, UnistylesShadowRegistry } from '../../specs'
 import type { UnistylesTheme } from '../../types'
-import type { PartialBy } from '../../types/common'
 import { deepMergeObjects } from '../../utils'
 import { useProxifiedUnistyles } from '../useProxifiedUnistyles'
 import { maybeWarnAboutMultipleUnistyles } from '../warn'
-import type { Mappings, SupportedStyleProps } from './types'
+import type { Mappings } from './types'
 
 // @ts-expect-error
 type GenericComponentProps<P> = ComponentProps<P>
@@ -24,7 +23,7 @@ type MappedSecrets = {
 
 export const withUnistyles = <TComponent, TMappings extends GenericComponentProps<TComponent>>(Component: TComponent, mappings?: Mappings<TMappings>) => {
     type TProps = GenericComponentProps<TComponent>
-    type PropsWithUnistyles = PartialBy<TProps, keyof TMappings | SupportedStyleProps> & {
+    type PropsWithUnistyles = Partial<TProps> & {
         uniProps?: Mappings<TProps>
     }
     const getSecrets = (styleProps: Record<string, any> = {}): MappedSecrets => {

--- a/src/core/withUnistyles/withUnistyles.tsx
+++ b/src/core/withUnistyles/withUnistyles.tsx
@@ -1,11 +1,10 @@
 import React, { type ComponentType, forwardRef, type ComponentProps, type ComponentRef } from 'react'
 import type { UnistylesValues } from '../../types'
-import type { PartialBy } from '../../types/common'
 import { deepMergeObjects } from '../../utils'
 import { getClassName } from '../getClassname'
 import { useProxifiedUnistyles } from '../useProxifiedUnistyles'
 import { maybeWarnAboutMultipleUnistyles } from '../warn'
-import type { Mappings, SupportedStyleProps } from './types'
+import type { Mappings } from './types'
 
 // @ts-expect-error
 type GenericComponentProps<T> = ComponentProps<T>
@@ -14,7 +13,7 @@ type GenericComponentRef<T> = ComponentRef<T>
 
 export const withUnistyles = <TComponent, TMappings extends GenericComponentProps<TComponent>>(Component: TComponent, mappings?: Mappings<TMappings>) => {
     type TProps = GenericComponentProps<TComponent>
-    type PropsWithUnistyles = PartialBy<TProps, keyof TMappings | SupportedStyleProps> & {
+    type PropsWithUnistyles = Partial<TProps> & {
         uniProps?: Mappings<TProps>
     }
     type UnistyleStyles = {

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -1,5 +1,4 @@
 export type Optional<T> = T | undefined
 export type Nullable<T> = T | null
 export type SafeReturnType<T> = T extends (...args: any) => infer R ? R : T
-export type PartialBy<T, K> = Omit<T, K & keyof T> & Partial<Pick<T, K & keyof T>>
 export type UnionToIntersection<U> = (U extends any ? (k: U) => void : never) extends (k: infer I) => void ? I : never


### PR DESCRIPTION
## Summary

Due to complex types parsing some Components types are not parsed correctly, for example `Rect` from `@shopify/react-native-skia`

Before:
![image](https://github.com/user-attachments/assets/299cb452-4df7-4051-a3bc-a3eb9ab7aed7)

After:
![image](https://github.com/user-attachments/assets/40f15814-8db5-4eea-ba80-8c2e0e86fbac)
