### PR TITLE
feat: withUnistyles div support

### DIFF
--- a/src/core/getClassname.ts
+++ b/src/core/getClassname.ts
@@ -1,13 +1,14 @@
 import type { UnistylesValues } from '../types'
 import { UnistylesWeb } from '../web'
 
-export const getClassName = (unistyle: UnistylesValues | undefined | Array<UnistylesValues>) => {
+export const getClassName = (unistyle: UnistylesValues | undefined | Array<UnistylesValues>, forChild?: boolean) => {
     if (!unistyle) {
         return undefined
     }
 
     const { hash, injectedClassName } = UnistylesWeb.shadowRegistry.addStyles(
-        Array.isArray(unistyle) ? unistyle.flat(Number.POSITIVE_INFINITY) : [unistyle]
+        Array.isArray(unistyle) ? unistyle.flat(Number.POSITIVE_INFINITY) : [unistyle],
+        forChild
     )
 
     return hash ? { $$css: true, hash, injectedClassName } : undefined

--- a/src/web/registry.ts
+++ b/src/web/registry.ts
@@ -92,8 +92,11 @@ export class UnistylesRegistry {
         return false
     }
 
-    add = (value: UnistylesValues) => {
-        const hash = generateHash(value)
+    add = (value: UnistylesValues, forChild?: boolean) => {
+        const generatedHash = generateHash(value)
+        const hash = forChild
+            ? `${generatedHash} > *`
+            : generatedHash
 
         if (!this.stylesCache.has(hash)) {
             this.applyStyles(hash, value)

--- a/src/web/shadowRegistry.ts
+++ b/src/web/shadowRegistry.ts
@@ -27,7 +27,7 @@ export class UnistylesShadowRegistry {
         this.services.registry.connect(ref, hash)
     }
 
-    addStyles = (unistyles: Array<UnistylesValues>) => {
+    addStyles = (unistyles: Array<UnistylesValues>, forChild?: boolean) => {
         const getParsedStyles = () => {
             const allStyles = unistyles.map(unistyle => {
                 const secrets = extractSecrets(unistyle)
@@ -61,7 +61,7 @@ export class UnistylesShadowRegistry {
         // Copy scoped theme to not use referenced value
         const scopedTheme = this.scopedTheme
         const parsedStyles = getParsedStyles()
-        const { hash, existingHash } = this.services.registry.add(parsedStyles)
+        const { hash, existingHash } = this.services.registry.add(parsedStyles, forChild)
         const injectedClassNames = parsedStyles?._web?._classNames ?? []
         const injectedClassName = Array.isArray(injectedClassNames) ? injectedClassNames.join(' ') : injectedClassNames
         const dependencies = extractUnistyleDependencies(parsedStyles)
@@ -75,7 +75,11 @@ export class UnistylesShadowRegistry {
             }))
         }
 
-        return { injectedClassName, hash }
+        const hashClassname = forChild
+            ? hash.replace(' > *', '')
+            : hash
+
+        return { injectedClassName, hash: hashClassname }
     }
 
     setScopedTheme = (theme?: UnistylesTheme) => {


### PR DESCRIPTION
## Summary

#654

Implement [proposal](https://github.com/jpudysz/react-native-unistyles/issues/654#issuecomment-2723829549) by @lundenmiika

Quick summary:
When component is wrapped with `withUnistyles` in a DOM it is wrapper with a `div` that has `display: contents` and applies generated className into it's children
```html
<div className="unistyles_t6zr8e375u" style="display: contents">
// Component
</div>
```
```css
.unistyles_t6zr8e375u > * {
 // styles
}
```

https://github.com/user-attachments/assets/f23dc889-f180-4498-8316-47d6355bde9b




