### PR TITLE
fix: add nullcheck for empty styles in withUnistyles

### DIFF
--- a/src/core/withUnistyles/withUnistyles.tsx
+++ b/src/core/withUnistyles/withUnistyles.tsx
@@ -30,9 +30,14 @@ export const withUnistyles = <TComponent, TMappings extends GenericComponentProp
         const mappingsProps = mappings ? mappings(proxifiedTheme, proxifiedRuntime) : {}
         const unistyleProps = narrowedProps.uniProps ? narrowedProps.uniProps(proxifiedTheme, proxifiedRuntime) : {}
 
-        const emptyStyles = Object.fromEntries(Object.entries(Object.getOwnPropertyDescriptors(narrowedProps.style))
-            .filter(([key]) => !key.startsWith('unistyles') && !key.startsWith('_'))
-            .map(([key]) => [key, undefined]))
+
+        const emptyStyles = narrowedProps.style
+            ? Object.fromEntries(
+                  Object.entries(Object.getOwnPropertyDescriptors(narrowedProps.style))
+                      .filter(([key]) => !key.startsWith("unistyles") && !key.startsWith("_"))
+                      .map(([key]) => [key, undefined])
+              )
+            : undefined
 
         const combinedProps = {
             ...deepMergeObjects(mappingsProps, unistyleProps, props),


### PR DESCRIPTION
## Summary
Using `withUnistyles` with only `contentContainerStyle` (without style prop) causes a TypeError:


```
Uncaught TypeError: Cannot convert undefined or null to object
    at Object.getOwnPropertyDescriptors (<anonymous>)
```

#### Example:
```tsx
const UnistylesScrollView = withUnistyles(ScrollView);

<UnistylesScrollView contentContainerStyle={styles.navContainer}>
  {/* content */}
</UnistylesScrollView>
```
![image](https://github.com/user-attachments/assets/5d6e9487-a7f9-4157-9377-eedea3518285)


## Changes
- Add null check before accessing `narrowedProps.style` in `withUnistyles`
