### PR TITLE
fix: unistyles with react-compiler

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -96,6 +96,7 @@ export default defineConfig({
                         { label: 'Theming', slug: 'v3/guides/theming' },
                         { label: 'Avoiding Keyboard', slug: 'v3/guides/avoiding-keyboard' },
                         { label: 'Expo Router', slug: 'v3/guides/expo-router' },
+                        { label: 'React Compiler', slug: 'v3/guides/react-compiler', badge: 'New!' },
                         { label: 'Custom web', slug: 'v3/guides/custom-web', badge: 'WIP' },
                         { label: 'Server side rendering', slug: 'v3/guides/server-side-rendering' },
                     ]

--- a/docs/src/content/docs/v3/guides/react-compiler.mdx
+++ b/docs/src/content/docs/v3/guides/react-compiler.mdx
@@ -1,0 +1,39 @@
+---
+title: React Compiler
+description: Integrate React Compiler with Unistyles
+---
+
+import { Card, Aside } from '@astrojs/starlight/components'
+import Seo from '../../../../components/Seo.astro'
+
+<Seo
+    seo={{
+        title: 'React Compiler',
+        description: 'Integrate React Compiler with Unistyles',
+    }}
+>
+React Compiler is a build-time only tool that automatically optimizes your React app. When using Unistyles with React Compiler, it's necessary to configure it properly.
+
+# With Expo
+Follow official [expo guide](https://docs.expo.dev/guides/react-compiler/), no changes are required!
+
+# With bare React Native
+Follow official [react guide](https://react.dev/learn/react-compiler#usage-with-babel) with a one major difference:
+
+It is crucial that React Compiler is run *after* Unistyles Babel plugin. Otherwise, issues will occur.
+
+It is due to the fact that Unistyles must parse `Variants` before React Compiler. You can learn more about how the Babel plugin works [here](/v3/other/babel-plugin)
+
+```diff lang="js" title="babel.config.js"
+module.exports = function () {
+  return {
+    plugins: [
+      ['react-native-unistyles/plugin'], // Must run before react-compiler
++      'babel-plugin-react-compiler',
+      // Rest of the plugins
+    ]
+  }
+}
+```
+</Seo>
+

--- a/docs/src/content/docs/v3/guides/react-compiler.mdx
+++ b/docs/src/content/docs/v3/guides/react-compiler.mdx
@@ -12,25 +12,27 @@ import Seo from '../../../../components/Seo.astro'
         description: 'Integrate React Compiler with Unistyles',
     }}
 >
-React Compiler is a build-time only tool that automatically optimizes your React app. When using Unistyles with React Compiler, it's necessary to configure it properly.
+React Compiler is a build-time tool that automatically optimizes your React app. To integrate Unistyles with React Compiler, proper configuration is essential.
 
-# With Expo
-Follow official [expo guide](https://docs.expo.dev/guides/react-compiler/), no changes are required!
+## With Expo
 
-# With bare React Native
-Follow official [react guide](https://react.dev/learn/react-compiler#usage-with-babel) with a one major difference:
+For Expo projects, simply follow the [official Expo guide](https://docs.expo.dev/guides/react-compiler/). No additional configuration changes are necessary!
 
-It is crucial that React Compiler is run *after* Unistyles Babel plugin. Otherwise, issues will occur.
+## With Bare React Native
 
-It is due to the fact that Unistyles must parse `Variants` before React Compiler. You can learn more about how the Babel plugin works [here](/v3/other/babel-plugin)
+For bare React Native projects, refer to the [official React guide](https://react.dev/learn/react-compiler#usage-with-babel) with one key adjustment:
+
+Ensure that the React Compiler runs *after* the Unistyles Babel plugin. Failure to do so may result in errors because Unistyles needs to process `Variants` before the React Compiler does. You can read more about the Babel plugin [here](/v3/other/babel-plugin).
+
+Here's a sample configuration for your `babel.config.js`:
 
 ```diff lang="js" title="babel.config.js"
 module.exports = function () {
   return {
     plugins: [
       ['react-native-unistyles/plugin'], // Must run before react-compiler
-+      'babel-plugin-react-compiler',
-      // Rest of the plugins
++     'babel-plugin-react-compiler',
+      // Add other plugins here
     ]
   }
 }

--- a/docs/src/content/docs/v3/other/babel-plugin.mdx
+++ b/docs/src/content/docs/v3/other/babel-plugin.mdx
@@ -302,6 +302,10 @@ Defaults to:
 In order to list detected dependencies by the Babel plugin you can enable the `debug` flag.
 It will `console.log` name of the file and component with Unistyles dependencies.
 
+### Usage with React Compiler
+
+Check [this guide](/v3/guides/react-compiler) for more details.
+
 #### Usage in `babel.config.js`
 
 You can apply any of the options above as follows:

--- a/docs/src/content/docs/v3/start/getting-started.mdx
+++ b/docs/src/content/docs/v3/start/getting-started.mdx
@@ -72,6 +72,8 @@ module.exports = function (api) {
 <Aside>
 Learn more on how the Babel plugin works [here](/v3/other/babel-plugin).
 
+If you're using React Compiler, check [this guide](/v3/guides/react-compiler) for more details.
+
 Check extra configuration options [here](/v3/other/babel-plugin#extra-configuration).
 </Aside>
 


### PR DESCRIPTION
## Summary

fixes #368 

React Compiler does all of the parsing on the `Program.enter` so we need to parse our `variants` before it happens

Video (running reproduction from #368 issue with updated plugin):

https://github.com/user-attachments/assets/7c6d145a-2f33-4977-af9f-6a71134cd013

