### PR TITLE
fix: nextjs client components

### DIFF
--- a/docs/src/content/docs/v3/guides/server-side-rendering.mdx
+++ b/docs/src/content/docs/v3/guides/server-side-rendering.mdx
@@ -24,15 +24,24 @@ Unistyles 3.0 is fully compatible with Next.js Server Side Rendering (SSR). We'r
         ```tsx title="Style.tsx" /useServerUnistyles/ /useServerInsertedHTML/ /'use client'/
         'use client'
 
-        import { PropsWithChildren } from 'react'
+        import { PropsWithChildren, useRef } from 'react'
         import { useServerUnistyles } from 'react-native-unistyles/server'
         import { useServerInsertedHTML } from 'next/navigation'
         import './unistyles'
 
         export const Style = ({ children }: PropsWithChildren) => {
+            const isServerInserted = useRef(false)
             const unistyles = useServerUnistyles()
 
-            useServerInsertedHTML(() => unistyles)
+            useServerInsertedHTML(() => {
+                if (isServerInserted.current) {
+                    return null
+                }
+
+                isServerInserted.current = true
+
+                return unistyles
+            })
 
             return <>{children}</>
         }
@@ -113,3 +122,24 @@ Unistyles 3.0 is fully compatible with Next.js Server Side Rendering (SSR). We'r
 
 
 </Seo>
+
+## Troubleshooting
+
+### Hydration error
+
+If you're not using adaptive themes, you might encounter hydration error on your root html element.
+This is because unistyles is adding a className to it based on the current theme.
+
+To fix this simply add `suppressHydrationWarning` to your root html element.
+
+```diff lang="tsx" title="layout.tsx"
+- <html lang="en">
++ <html lang="en" suppressHydrationWarning>
+```
+
+Or you can directly add the className to your root html element.
+
+```diff lang="tsx" title="layout.tsx"
+- <html lang="en">
++ <html lang="en" className="dark">
+```

--- a/src/server/getServerUnistyles.tsx
+++ b/src/server/getServerUnistyles.tsx
@@ -2,8 +2,8 @@ import React from 'react'
 import { StyleSheet } from 'react-native'
 import { UnistylesWeb } from '../web'
 import { error, isServer } from '../web/utils'
-import { DefaultServerUnistylesSettings, type ServerUnistylesSettings } from './types'
 import { serialize } from './serialize'
+import { DefaultServerUnistylesSettings, type ServerUnistylesSettings } from './types'
 
 export const getServerUnistyles = ({ includeRNWStyles = true }: ServerUnistylesSettings = DefaultServerUnistylesSettings) => {
     if (!isServer()) {

--- a/src/server/getServerUnistyles.tsx
+++ b/src/server/getServerUnistyles.tsx
@@ -3,19 +3,24 @@ import { StyleSheet } from 'react-native'
 import { UnistylesWeb } from '../web'
 import { error, isServer } from '../web/utils'
 import { DefaultServerUnistylesSettings, type ServerUnistylesSettings } from './types'
+import { serialize } from './serialize'
 
 export const getServerUnistyles = ({ includeRNWStyles = true }: ServerUnistylesSettings = DefaultServerUnistylesSettings) => {
     if (!isServer()) {
         throw error('Server styles should only be read on the server')
     }
+
     // @ts-ignore
     const rnwStyle: string | null = includeRNWStyles ? (StyleSheet?.getSheet().textContent ?? '') : null
     const css = UnistylesWeb.registry.css.getStyles()
     const state = UnistylesWeb.registry.css.getState()
-    return <>
-        {rnwStyle && <style id='rnw-style'>{rnwStyle}</style>}
-        <style id='unistyles-web'>{css}</style>
-        {/* biome-ignore lint/security/noDangerouslySetInnerHtml: Needs the json quotes to be unescaped */}
-        <script id='unistyles-script' dangerouslySetInnerHTML={{ __html: `window.__UNISTYLES_STATE__ = ${JSON.stringify(state)}`}} />
-    </>
+
+    return (
+        <>
+            {rnwStyle && <style id='rnw-style'>{rnwStyle}</style>}
+            <style id='unistyles-web'>{css}</style>
+            {/* biome-ignore lint/security/noDangerouslySetInnerHtml: Needs the json quotes to be unescaped */}
+            <script id='unistyles-script' defer dangerouslySetInnerHTML={{ __html: `window.__UNISTYLES_STATE__ = ${serialize(state)}`}} />
+        </>
+    )
 }

--- a/src/server/serialize.ts
+++ b/src/server/serialize.ts
@@ -1,0 +1,20 @@
+export const serialize = (value: any): string => {
+    switch (typeof value) {
+        case 'function':
+            return value.toString()
+        case 'object':
+            if (Array.isArray(value)) {
+                return `[${value.map(serialize).join(',')}]`
+            }
+
+            if (value === null) {
+                return 'null'
+            }
+
+            return `{${Object.entries(value)
+                .map(([key, value]) => `${key}:${serialize(value)}`)
+                .join(',')}}`
+        default:
+            return JSON.stringify(value)
+    }
+}

--- a/src/web/create.ts
+++ b/src/web/create.ts
@@ -1,12 +1,19 @@
 import type { StyleSheet, StyleSheetWithSuperPowers } from '../types/stylesheet'
 import { UnistylesWeb } from './index'
-import { assignSecrets, error, removeInlineStyles } from './utils'
+import { assignSecrets, error, isServer, removeInlineStyles } from './utils'
 
 type Variants = Record<string, string | boolean | undefined>
 
 export const create = (stylesheet: StyleSheetWithSuperPowers<StyleSheet>, id?: string) => {
     if (!id) {
         throw error('Unistyles is not initialized correctly. Please add babel plugin to your babel config.')
+    }
+
+    // For SSR
+    if (!UnistylesWeb.state.isInitialized && !isServer()) {
+        const config = window?.__UNISTYLES_STATE__?.config
+
+        config && UnistylesWeb.state.init(config)
     }
 
     const computedStylesheet = UnistylesWeb.registry.getComputedStylesheet(stylesheet)

--- a/src/web/css/state.ts
+++ b/src/web/css/state.ts
@@ -1,5 +1,6 @@
 import type { UnistylesValues } from '../../types'
 import { convertUnistyles } from '../convert'
+import type { UnistylesServices } from '../types'
 import { hyphenate, isServer } from '../utils'
 import { convertToCSS } from './core'
 
@@ -33,7 +34,7 @@ export class CSSState {
     private styleTag: HTMLStyleElement | null = null
     private CSS = ''
 
-    constructor() {
+    constructor(private services: UnistylesServices) {
         if (isServer()) {
             return
         }
@@ -159,8 +160,9 @@ export class CSSState {
 
         const mainState = getState(this.mainMap)
         const mqState = getState(this.mqMap)
+        const config = this.services.state.getConfig()
 
-        return { mainState, mqState }
+        return { mainState, mqState, config }
     }
 
     hydrate = ({ mainState, mqState }: ReturnType<typeof this.getState>) => {

--- a/src/web/registry.ts
+++ b/src/web/registry.ts
@@ -11,9 +11,11 @@ export class UnistylesRegistry {
     private readonly stylesCounter = new Map<string, Set<HTMLElement>>()
     private readonly disposeListenersMap = new Map<object, VoidFunction>()
     private readonly dependenciesMap = new Map<StyleSheetWithSuperPowers<StyleSheet>, Set<UnistyleDependency>>()
-    readonly css = new CSSState()
+    readonly css: CSSState
 
-    constructor(private services: UnistylesServices) {}
+    constructor(private services: UnistylesServices) {
+        this.css = new CSSState(services)
+    }
 
     getComputedStylesheet = (stylesheet: StyleSheetWithSuperPowers<StyleSheet>, scopedThemeName?: UnistylesTheme) => {
         if (typeof stylesheet !== 'function') {

--- a/src/web/state.ts
+++ b/src/web/state.ts
@@ -17,6 +17,7 @@ export class UnistylesState {
     CSSVars = true
 
     private matchingBreakpoints = new Map<string, boolean>()
+    private _config: UnistylesConfig = {}
 
     get breakpoint() {
         const [currentBreakpoint] = Array.from(this.matchingBreakpoints)
@@ -37,6 +38,7 @@ export class UnistylesState {
             return
         }
 
+        this._config = config
         this.isInitialized = true
         this.initThemes(config.themes, config.settings?.CSSVars)
         this.initBreakpoints(config.breakpoints)
@@ -153,4 +155,6 @@ export class UnistylesState {
                 })
             })
     }
+
+    getConfig = () => this._config
 }


### PR DESCRIPTION
## Summary

fixes #691

- update the SSR docs
- serialize config and inject this into client

Next.js lacks a single, guaranteed entry point for client-side code execution. To ensure our configuration is available from the start, we need to inject inject our config from the server side into window directly. To initialize our configuration, we make a optional init call within the StyleSheet.create, guaranteeing it runs early in the client-side lifecycle before any components are rendered.

SSR documentation was updated because:
- useServerInsertedHTML may be inserted multiple times without additional logic with a `useRef`
- unistyles caused hydration warnings due to adding className to the root html element
