### PR TITLE
fix(web): Update StyleSheet.flatten to comply with official's API

### DIFF
--- a/src/web/index.ts
+++ b/src/web/index.ts
@@ -35,7 +35,7 @@ export const StyleSheet = {
         bottom: 0
     },
     compose: (a: object, b: object) => deepMergeObjects(a, b),
-    flatten: (...styles: Array<object>) => deepMergeObjects(...styles),
+    flatten: (styles: Array<object>) => deepMergeObjects(...styles),
     hairlineWidth: 1
 } as unknown as typeof NativeStyleSheet
 


### PR DESCRIPTION
## Summary


`StyleSheet.flatten` in `react-native` only flatten 1 array of styles, (see [doc](https://reactnative.dev/docs/stylesheet#flatten)):

```ts
static flatten(style: Array<Object extends Record<string, ViewStyle | ImageStyle | TextStyle>>): Object;
```

However in the web implementation of we expect the array to be taken in multiple args instead.


----

Side question: does flatten works with unistyle's styles?