### PR TITLE
fix: serialize config

### DIFF
--- a/src/server/serialize.ts
+++ b/src/server/serialize.ts
@@ -12,7 +12,7 @@ export const serialize = (value: any): string => {
             }
 
             return `{${Object.entries(value)
-                .map(([key, value]) => `${key}:${serialize(value)}`)
+                .map(([key, value]) => `'${key}':${serialize(value)}`)
                 .join(',')}}`
         default:
             return JSON.stringify(value)


### PR DESCRIPTION
## Summary

fixes #698 

Now `serialize` function wraps every object's key with single quotes to prevent invalid js syntax