### PR TITLE
fix: condition to allow parsing libraries with unistyles from node_modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,27 +22,23 @@
     ".": {
       "types": "./lib/typescript/src/index.d.ts",
       "import": "./lib/module/index.js",
-      "require": "./lib/commonjs/index.js",
       "react-native": "./src/index.ts",
       "default": "./lib/commonjs/index.js"
     },
     "./components/native/*": {
       "import": "./lib/module/components/native/*",
-      "require": "./lib/commonjs/components/native/*",
       "react-native": "./src/components/native/*",
       "default": "./lib/commonjs/components/native/*"
     },
     "./plugin": {
       "import": "./plugin/index.js",
       "types": "./plugin/index.d.ts",
-      "require": "./plugin/index.js",
       "default": "./plugin/index.js"
     },
     "./package.json": "./package.json",
     "./server": {
       "types": "./lib/typescript/src/server/index.d.ts",
       "import": "./lib/module/server/index.js",
-      "require": "./lib/commonjs/server/index.js",
       "react-native": "./src/server.ts",
       "default": "./lib/commonjs/server/index.js"
     }

--- a/plugin/index.js
+++ b/plugin/index.js
@@ -169,7 +169,7 @@ function addUnistylesImport(path2, state) {
   nodesToRemove.forEach((node) => path2.node.body.splice(path2.node.body.indexOf(node), 1));
 }
 function isInsideNodeModules(state) {
-  return state.file.opts.filename?.includes("node_modules");
+  return state.file.opts.filename?.includes("node_modules") && !state.file.replaceWithUnistyles;
 }
 
 // plugin/src/ref.ts
@@ -706,7 +706,7 @@ function index_default() {
           });
         },
         exit(path2, state) {
-          if (isInsideNodeModules(state) && !state.file.replaceWithUnistyles) {
+          if (isInsideNodeModules(state)) {
             return;
           }
           if (state.file.hasAnyUnistyle || state.file.hasVariants || state.file.replaceWithUnistyles || state.file.forceProcessing) {
@@ -750,7 +750,7 @@ function index_default() {
         if (exoticImport) {
           return handleExoticImport(path2, state, exoticImport);
         }
-        if (isInsideNodeModules(state) && !state.file.replaceWithUnistyles) {
+        if (isInsideNodeModules(state)) {
           return;
         }
         const importSource = path2.node.source.value;

--- a/plugin/src/import.ts
+++ b/plugin/src/import.ts
@@ -48,5 +48,5 @@ export function addUnistylesImport(path: NodePath<t.Program>, state: UnistylesPl
 }
 
 export function isInsideNodeModules(state: UnistylesPluginPass) {
-    return state.file.opts.filename?.includes('node_modules')
+    return state.file.opts.filename?.includes('node_modules') && !state.file.replaceWithUnistyles
 }

--- a/plugin/src/index.ts
+++ b/plugin/src/index.ts
@@ -41,7 +41,7 @@ export default function (): PluginObj<UnistylesPluginPass> {
                     })
                 },
                 exit(path, state) {
-                    if (isInsideNodeModules(state) && !state.file.replaceWithUnistyles) {
+                    if (isInsideNodeModules(state)) {
                         return
                     }
 
@@ -102,7 +102,7 @@ export default function (): PluginObj<UnistylesPluginPass> {
                     return handleExoticImport(path, state, exoticImport)
                 }
 
-                if (isInsideNodeModules(state) && !state.file.replaceWithUnistyles) {
+                if (isInsideNodeModules(state)) {
                     return
                 }
 


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated internal logic to refine how files inside certain directories are handled, ensuring more consistent processing.
	- Adjusted package configuration to simplify export definitions, improving compatibility and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Fixes #718 