### PR TITLE
feat: add support for commonjs require to detect stylesheets

### DIFF
--- a/plugin/src/index.ts
+++ b/plugin/src/index.ts
@@ -5,7 +5,7 @@ import { handleExoticImport } from './exotic'
 import { addUnistylesImport, isInsideNodeModules } from './import'
 import { toPlatformPath } from './paths'
 import { hasStringRef } from './ref'
-import { addDependencies, addStyleSheetTag, getStylesDependenciesFromFunction, getStylesDependenciesFromObject, isKindOfStyleSheet, isUnistylesStyleSheet } from './stylesheet'
+import { addDependencies, addStyleSheetTag, getStylesDependenciesFromFunction, getStylesDependenciesFromObject, isKindOfStyleSheet, isUnistylesCommonJSRequire, isUnistylesStyleSheet } from './stylesheet'
 import type { UnistylesPluginPass } from './types'
 import { extractVariants } from './variants'
 
@@ -145,6 +145,10 @@ export default function (): PluginObj<UnistylesPluginPass> {
             },
             CallExpression(path, state) {
                 if (isInsideNodeModules(state)) {
+                    return
+                }
+
+                if (isUnistylesCommonJSRequire(path, state)) {
                     return
                 }
 


### PR DESCRIPTION
## Summary

This is the first PR to add support for CommonJS in the Unistyles Babel plugin.  
This PR adds functionality to correctly detect StyleSheets.

Related to #707 

