### PR TITLE
feat: babel add support for commonjs components

### DIFF
--- a/plugin/src/import.ts
+++ b/plugin/src/import.ts
@@ -50,3 +50,16 @@ export function addUnistylesImport(path: NodePath<t.Program>, state: UnistylesPl
 export function isInsideNodeModules(state: UnistylesPluginPass) {
     return state.file.opts.filename?.includes('node_modules') && !state.file.replaceWithUnistyles
 }
+
+export function addUnistylesRequire(path: NodePath<t.Program>, state: UnistylesPluginPass) {
+    const newRequire = t.variableDeclaration('const', [
+        t.variableDeclarator(
+            t.identifier(state.file.styleSheetLocalName),
+            t.callExpression(t.identifier('require'), [
+                t.stringLiteral('react-native-unistyles')
+            ])
+        )
+    ])
+
+    path.node.body.unshift(newRequire)
+}

--- a/plugin/src/stylesheet.ts
+++ b/plugin/src/stylesheet.ts
@@ -205,6 +205,21 @@ export function isUnistylesCommonJSRequire(path: NodePath<t.CallExpression>, sta
     return isRequire
 }
 
+export function isReactNativeCommonJSRequire(path: NodePath<t.CallExpression>, state: UnistylesPluginPass) {
+    const isRequire = (
+        t.isIdentifier(path.node.callee) &&
+        path.node.arguments.length > 0 &&
+        t.isStringLiteral(path.node.arguments[0]) &&
+        (path.node.arguments[0]).value === 'react-native'
+    )
+
+    if (isRequire && t.isVariableDeclarator(path.parent) && t.isIdentifier(path.parent.id)) {
+        state.file.reactNativeCommonJSName = path.parent.id.name
+    }
+
+    return isRequire
+}
+
 export function isKindOfStyleSheet(path: NodePath<t.CallExpression>, state: UnistylesPluginPass) {
     if (!state.file.forceProcessing && !state.file.hasUnistylesImport) {
         return false

--- a/plugin/src/types.ts
+++ b/plugin/src/types.ts
@@ -5,10 +5,12 @@ interface UnistylesState {
     hasAnyUnistyle: boolean,
     hasVariants: boolean,
     hasUnistylesImport: boolean,
+    addUnistylesRequire: boolean,
     forceProcessing: boolean,
     styleSheetLocalName: string,
     tagNumber: number,
     replaceWithUnistyles: boolean
+    reactNativeCommonJSName: string
 }
 
 export interface UnistylesPluginPass {


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for handling CommonJS `require("react-native")` imports, ensuring they are detected and transformed consistently with ES module imports.
  - Automatically rewrites member expressions using React Native CommonJS imports to use Unistyles equivalents.
  - Injects the necessary Unistyles import when CommonJS patterns are detected.

- **Bug Fixes**
  - Improved compatibility with projects using different import styles for React Native, reducing potential transformation issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Maybe fixes #707