### PR TITLE
fix: babel path for commonjs and windows

### DIFF
--- a/plugin/index.js
+++ b/plugin/index.js
@@ -177,7 +177,7 @@ function addUnistylesRequire(path2, state) {
       t2.variableDeclarator(
         t2.identifier(uniqueName),
         t2.callExpression(t2.identifier("require"), [
-          t2.stringLiteral(`react-native-unistyles/src/components/native/${componentName}`)
+          t2.stringLiteral(toPlatformPath(`react-native-unistyles/src/components/native/${componentName}`))
         ])
       )
     ]);

--- a/plugin/src/import.ts
+++ b/plugin/src/import.ts
@@ -59,7 +59,7 @@ export function addUnistylesRequire(path: NodePath<t.Program>, state: UnistylesP
                 t.variableDeclarator(
                     t.identifier(uniqueName),
                     t.callExpression(t.identifier('require'), [
-                        t.stringLiteral(`react-native-unistyles/src/components/native/${componentName}`)
+                        t.stringLiteral(toPlatformPath(`react-native-unistyles/src/components/native/${componentName}`))
                     ])
                 )
             ])


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved compatibility for requiring components by ensuring module paths are correctly formatted for the current operating system. This enhances stability across different platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->