### PR TITLE
feat: filter commonjs react native names to components only

### DIFF
--- a/plugin/index.js
+++ b/plugin/index.js
@@ -831,6 +831,9 @@ function index_default() {
         if (path2.node.object.name !== state.file.reactNativeCommonJSName || !t6.isIdentifier(path2.node.property)) {
           return;
         }
+        if (!REACT_NATIVE_COMPONENT_NAMES.includes(path2.node.property.name)) {
+          return;
+        }
         if (!state.reactNativeImports[path2.node.property.name]) {
           const uniqueId = path2.scope.generateUidIdentifier(`reactNativeUnistyles_${path2.node.property.name}`);
           state.reactNativeImports[path2.node.property.name] = uniqueId.name;

--- a/plugin/src/index.ts
+++ b/plugin/src/index.ts
@@ -163,6 +163,10 @@ export default function (): PluginObj<UnistylesPluginPass> {
                     return
                 }
 
+                if (!REACT_NATIVE_COMPONENT_NAMES.includes(path.node.property.name)) {
+                    return
+                }
+
                 if (!state.reactNativeImports[path.node.property.name]) {
                     const uniqueId = path.scope.generateUidIdentifier(`reactNativeUnistyles_${path.node.property.name}`)
 


### PR DESCRIPTION
## Summary

Fixes #740 

Regression for #707 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of React Native components by only processing recognized component names, ensuring more accurate behavior when working with member expressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->