### PR TITLE
fix: web services imports

### DIFF
--- a/src/core/getClassname.ts
+++ b/src/core/getClassname.ts
@@ -1,5 +1,5 @@
 import type { UnistylesValues } from '../types'
-import { UnistylesWeb } from '../web'
+import * as unistyles from '../web/services'
 import { checkForAnimated } from '../web/utils'
 
 export const getClassName = (unistyle: UnistylesValues | undefined | Array<UnistylesValues>, forChild?: boolean) => {
@@ -11,7 +11,7 @@ export const getClassName = (unistyle: UnistylesValues | undefined | Array<Unist
     const animatedStyles = flattenedStyles.filter(checkForAnimated)
     const regularStyles = flattenedStyles.filter(style => !checkForAnimated(style))
 
-    const { hash, injectedClassName } = UnistylesWeb.shadowRegistry.addStyles(
+    const { hash, injectedClassName } = unistyles.services.shadowRegistry.addStyles(
         regularStyles,
         forChild
     )

--- a/src/core/useProxifiedUnistyles/listener.ts
+++ b/src/core/useProxifiedUnistyles/listener.ts
@@ -1,10 +1,10 @@
 import { UnistyleDependency } from '../../specs'
-import { UnistylesWeb } from '../../web'
+import * as unistyles from '../../web/services'
 import type { ListenerProps } from './types'
 
 export const listener = ({ dependencies, updateTheme, updateRuntime }: ListenerProps) => {
-    const disposeTheme = UnistylesWeb.listener.addListeners(dependencies.filter(dependency => dependency === UnistyleDependency.Theme), updateTheme)
-    const disposeRuntime = UnistylesWeb.listener.addListeners(dependencies.filter(dependency => dependency !== UnistyleDependency.Theme), updateRuntime)
+    const disposeTheme = unistyles.services.listener.addListeners(dependencies.filter(dependency => dependency === UnistyleDependency.Theme), updateTheme)
+    const disposeRuntime = unistyles.services.listener.addListeners(dependencies.filter(dependency => dependency !== UnistyleDependency.Theme), updateRuntime)
 
     return () => {
         disposeTheme()

--- a/src/server/getServerUnistyles.tsx
+++ b/src/server/getServerUnistyles.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { StyleSheet } from 'react-native'
-import { UnistylesWeb } from '../web'
+import * as unistyles from '../web/services'
 import { error, isServer } from '../web/utils'
 import { serialize } from './serialize'
 import { DefaultServerUnistylesSettings, type ServerUnistylesSettings } from './types'
@@ -12,8 +12,8 @@ export const getServerUnistyles = ({ includeRNWStyles = true }: ServerUnistylesS
 
     // @ts-ignore
     const rnwStyle: string | null = includeRNWStyles ? (StyleSheet?.getSheet().textContent ?? '') : null
-    const css = UnistylesWeb.registry.css.getStyles()
-    const state = UnistylesWeb.registry.css.getState()
+    const css = unistyles.services.registry.css.getStyles()
+    const state = unistyles.services.registry.css.getState()
 
     return (
         <>

--- a/src/server/hydrateServerUnistyles.ts
+++ b/src/server/hydrateServerUnistyles.ts
@@ -1,4 +1,4 @@
-import { UnistylesWeb } from '../web'
+import * as unistyles from '../web/services'
 import { error, isServer } from '../web/utils'
 
 declare global {
@@ -12,6 +12,7 @@ export const hydrateServerUnistyles = () => {
     if (isServer()) {
         throw error('Server styles should only be hydrated on the client')
     }
-    UnistylesWeb.registry.css.hydrate(window.__UNISTYLES_STATE__)
+
+    unistyles.services.registry.css.hydrate(window.__UNISTYLES_STATE__)
     document.querySelector('#unistyles-script')?.remove()
 }

--- a/src/server/resetServerUnistyles.ts
+++ b/src/server/resetServerUnistyles.ts
@@ -1,9 +1,10 @@
-import { UnistylesWeb } from '../web'
+import * as unistyles from '../web/services'
 import { error, isServer } from '../web/utils'
 
 export const resetServerUnistyles = () => {
     if (!isServer()) {
         throw error('Server styles should only be reset on the server')
     }
-    UnistylesWeb.registry.reset()
+
+    unistyles.services.registry.reset()
 }

--- a/src/web/convert/object/filter.ts
+++ b/src/web/convert/object/filter.ts
@@ -1,6 +1,6 @@
 import type { DropShadowValue } from 'react-native'
 import { isUnistylesMq } from '../../../mq'
-import { UnistylesWeb } from '../../index'
+import * as unistyles from '../../services'
 import { hyphenate } from '../../utils'
 import type { Filters } from '../types'
 import { normalizeColor, normalizeNumericValue } from '../utils'
@@ -21,7 +21,7 @@ export const getFilterStyle = (filters: Array<Filters>) => {
             return []
         }
 
-        const breakpoints = Object.keys(dropShadowValue).filter(key => Object.keys(UnistylesWeb.runtime.breakpoints).includes(key) || isUnistylesMq(key))
+        const breakpoints = Object.keys(dropShadowValue).filter(key => Object.keys(unistyles.services.runtime.breakpoints).includes(key) || isUnistylesMq(key))
         const breakpointsDropShadow = Object.fromEntries(breakpoints.map(breakpoint => [breakpoint, getDropShadowStyle(dropShadowValue[breakpoint])]))
 
         if (breakpoints.length === 0) {

--- a/src/web/create.ts
+++ b/src/web/create.ts
@@ -1,5 +1,5 @@
 import type { StyleSheet, StyleSheetWithSuperPowers } from '../types/stylesheet'
-import { UnistylesWeb } from './index'
+import * as unistyles from './services'
 import { assignSecrets, error, isServer, removeInlineStyles } from './utils'
 
 type Variants = Record<string, string | boolean | undefined>
@@ -10,13 +10,13 @@ export const create = (stylesheet: StyleSheetWithSuperPowers<StyleSheet>, id?: s
     }
 
     // For SSR
-    if (!UnistylesWeb.state.isInitialized && !isServer()) {
+    if (!unistyles.services.state.isInitialized && !isServer()) {
         const config = window?.__UNISTYLES_STATE__?.config
 
-        config && UnistylesWeb.state.init(config)
+        config && unistyles.services.state.init(config)
     }
 
-    const computedStylesheet = UnistylesWeb.registry.getComputedStylesheet(stylesheet)
+    const computedStylesheet = unistyles.services.registry.getComputedStylesheet(stylesheet)
     const addSecrets = (value: any, key: string, args = undefined as Array<any> | undefined, variants = {} as Variants) => assignSecrets(value, {
         __uni__key: key,
         __uni__stylesheet: stylesheet,

--- a/src/web/index.ts
+++ b/src/web/index.ts
@@ -3,22 +3,10 @@ import type { StyleSheet as NativeStyleSheet } from '../specs/StyleSheet'
 import type { Runtime as NativeUnistylesRuntime } from '../specs/UnistylesRuntime'
 import { deepMergeObjects } from '../utils'
 import { create } from './create'
-import { UnistylesServices } from './services'
-import { isServer } from './utils'
+import * as unistyles from './services'
 
-declare global {
-    // @ts-ignore
-    var __unistyles__: UnistylesServices
-}
-
-if (isServer() && !globalThis.__unistyles__) {
-    // @ts-ignore
-    globalThis.__unistyles__ = new UnistylesServices()
-}
-
-export const UnistylesWeb = isServer() ? globalThis.__unistyles__ : new UnistylesServices()
 export const StyleSheet = {
-    configure: UnistylesWeb.state.init,
+    configure: unistyles.services.state.init,
     create: create,
     absoluteFill: {
         position: 'absolute',
@@ -39,8 +27,8 @@ export const StyleSheet = {
     hairlineWidth: 1
 } as unknown as typeof NativeStyleSheet
 
-export const UnistylesRuntime = UnistylesWeb.runtime as unknown as typeof NativeUnistylesRuntime
-export const UnistylesShadowRegistry = UnistylesWeb.shadowRegistry as unknown as typeof NativeUnistylesShadowRegistry
+export const UnistylesRuntime = unistyles.services.runtime as unknown as typeof NativeUnistylesRuntime
+export const UnistylesShadowRegistry = unistyles.services.shadowRegistry as unknown as typeof NativeUnistylesShadowRegistry
 
 export * from './mock'
 

--- a/src/web/services.ts
+++ b/src/web/services.ts
@@ -3,8 +3,9 @@ import { UnistylesRegistry } from './registry'
 import { UnistylesRuntime } from './runtime'
 import { UnistylesShadowRegistry } from './shadowRegistry'
 import { UnistylesState } from './state'
+import { isServer } from './utils'
 
-export class UnistylesServices {
+class UnistylesServices {
     runtime: UnistylesRuntime
     registry: UnistylesRegistry
     shadowRegistry: UnistylesShadowRegistry
@@ -26,3 +27,15 @@ export class UnistylesServices {
         this.services.listener = this.listener
     }
 }
+
+declare global {
+    // @ts-ignore
+    var __unistyles__: UnistylesServices
+}
+
+if (isServer() && !globalThis.__unistyles__) {
+    // @ts-ignore
+    globalThis.__unistyles__ = new UnistylesServices()
+}
+
+export const services = isServer() ? globalThis.__unistyles__ : new UnistylesServices()

--- a/src/web/utils/createUnistylesRef.ts
+++ b/src/web/utils/createUnistylesRef.ts
@@ -1,6 +1,6 @@
 import type React from 'react'
 import type { Nullable, UnistylesValues } from '../../types'
-import { UnistylesWeb } from '../index'
+import * as unistyles from '../services'
 import { isServer } from './common'
 
 type Styles = readonly [
@@ -16,11 +16,11 @@ export const createUnistylesRef = <T>(styles?: Styles, forwardedRef?: React.Forw
 
     return isServer() ? undefined : (ref: Nullable<T>) => {
         if (!ref) {
-            UnistylesWeb.shadowRegistry.remove(storedRef, classNames?.hash)
+            unistyles.services.shadowRegistry.remove(storedRef, classNames?.hash)
         }
 
         storedRef.current = ref
-        UnistylesWeb.shadowRegistry.add(ref, classNames?.hash)
+        unistyles.services.shadowRegistry.add(ref, classNames?.hash)
 
         if (typeof forwardedRef === 'function') {
             return forwardedRef(ref)

--- a/src/web/utils/unistyle.ts
+++ b/src/web/utils/unistyle.ts
@@ -4,7 +4,7 @@ import { isUnistylesMq, parseMq } from '../../mq'
 import type { UnistyleDependency } from '../../specs/NativePlatform'
 import { ColorScheme, Orientation } from '../../specs/types'
 import type { StyleSheet, StyleSheetWithSuperPowers, UnistylesValues } from '../../types/stylesheet'
-import { UnistylesWeb } from '../index'
+import * as unistyles from '../services'
 import { keyInObject, reduceObject } from './common'
 
 export const schemeToTheme = (scheme: ColorScheme) => {
@@ -82,10 +82,10 @@ export const getMediaQuery = (query: string, allBreakpoints: Array<string>) => {
         return `@media ${queries}`
     }
 
-    const breakpointValue = UnistylesWeb.runtime.breakpoints[query as keyof UnistylesBreakpoints] ?? 0
+    const breakpointValue = unistyles.services.runtime.breakpoints[query as keyof UnistylesBreakpoints] ?? 0
     const nextBreakpoint = allBreakpoints
-        .filter((b): b is keyof UnistylesBreakpoints => b in UnistylesWeb.runtime.breakpoints)
-        .map(b => UnistylesWeb.runtime.breakpoints[b] as number)
+        .filter((b): b is keyof UnistylesBreakpoints => b in unistyles.services.runtime.breakpoints)
+        .map(b => unistyles.services.runtime.breakpoints[b] as number)
         .sort((a, b) => a - b)
         .find(b => b > breakpointValue)
     const queries = [


### PR DESCRIPTION
## Summary

fixes #746 

Fix circular dependency by moving UnistylesServices into `services.ts`, and use `import * as` to defer the access to the specific export until later.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated internal service imports and references throughout the codebase for improved consistency.
  - Simplified service usage by introducing a unified services namespace.
  - Implemented a singleton pattern for server-side service instances while maintaining per-instance usage on the client.

- **Chores**
  - Removed legacy server-side singleton initialization logic for cleaner module structure.

No changes to user-facing features or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->