### PR TITLE
feat: add React-jsinspectortracing dependency to podspec for static frameworks

### DIFF
--- a/Unistyles.podspec
+++ b/Unistyles.podspec
@@ -29,6 +29,7 @@ Pod::Spec.new do |s|
   if ENV["USE_FRAMEWORKS"]
     s.dependency "React-Core"
     add_dependency(s, "React-jsinspector", :framework_name => "jsinspector_modern")
+    add_dependency(s, "React-jsinspectortracing", :framework_name => 'jsinspector_moderntracing')
     add_dependency(s, "React-rendererconsistency", :framework_name => "React_rendererconsistency")
   end
 


### PR DESCRIPTION
## Summary

Fixes #756 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated dependencies to include an additional React-related framework when specific build conditions are met.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->