### PR TITLE
fix: babel paths windows

### DIFF
--- a/plugin/src/paths.ts
+++ b/plugin/src/paths.ts
@@ -1,9 +1,9 @@
-import * as path from 'node:path'
-
 const isWindows = process.platform === 'win32'
 
 const toWinPath = (pathString: string) => {
-    return path.normalize(pathString).replace(/\//g, '\\')
+    // todo not sure if we need it at all
+    // return path.normalize(pathString).replace(/\//g, '\\')
+    return pathString
 }
 
 export const toPlatformPath = (pathString: string) => {


### PR DESCRIPTION
## Summary

Fixes #752 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated internal path handling to return input paths unchanged on all platforms, without modifying slashes or normalizing.
  
- **Chores**
  - Removed unused import of the Node.js path module.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->