### PR TITLE
fix: improve hairline width calculation to handle zero width edge case

### DIFF
--- a/cxx/hybridObjects/HybridStyleSheet.cpp
+++ b/cxx/hybridObjects/HybridStyleSheet.cpp
@@ -3,10 +3,14 @@
 using namespace facebook::react;
 
 double HybridStyleSheet::getHairlineWidth() {
-    auto pixelRatio = this->_unistylesRuntime->getPixelRatio();
-    auto nearestPixel = static_cast<int>(std::trunc(pixelRatio * 0.4));
+    double pixelRatio = this->_unistylesRuntime->getPixelRatio();
+    double hairlineWidth = std::round(pixelRatio * 0.4) / pixelRatio;
 
-    return nearestPixel / pixelRatio;
+    if (hairlineWidth == 0.0) {
+        hairlineWidth = 1.0 / pixelRatio;
+    }
+
+    return hairlineWidth;
 }
 
 double HybridStyleSheet::getUnid() {


### PR DESCRIPTION
## Summary

Fixes #790 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved calculation of hairline width to ensure it is never zero, providing more consistent and visible thin lines across different display settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->