### PR TITLE
feat: add shadow tree flush mechanism for scoped theme updates

### DIFF
--- a/cxx/hybridObjects/HybridShadowRegistry.cpp
+++ b/cxx/hybridObjects/HybridShadowRegistry.cpp
@@ -107,13 +107,18 @@ jsi::Value HybridShadowRegistry::unlink(jsi::Runtime &rt, const jsi::Value &this
     return jsi::Value::undefined();
 }
 
+jsi::Value HybridShadowRegistry::flush(jsi::Runtime &rt, const jsi::Value &thisValue, const jsi::Value *args, size_t count) {
+    shadow::ShadowTreeManager::updateShadowTree(UIManagerBinding::getBinding(rt)->getUIManager().getShadowTreeRegistry());
+
+    return jsi::Value::undefined();
+}
+
 jsi::Value HybridShadowRegistry::setScopedTheme(jsi::Runtime &rt, const jsi::Value &thisValue, const jsi::Value *args, size_t count) {
     helpers::assertThat(rt, count == 1, "Unistyles: setScopedTheme expected 1 argument.");
 
     auto& registry = core::UnistylesRegistry::get();
 
     if (args[0].isUndefined()) {
-
         registry.setScopedTheme(std::nullopt);
     }
 

--- a/cxx/hybridObjects/HybridShadowRegistry.h
+++ b/cxx/hybridObjects/HybridShadowRegistry.h
@@ -5,6 +5,7 @@
 #include "UnistyleWrapper.h"
 #include "UnistylesState.h"
 #include "UnistylesRegistry.h"
+#include "ShadowTreeManager.h"
 
 namespace margelo::nitro::unistyles {
 
@@ -17,6 +18,10 @@ struct HybridShadowRegistry: public HybridUnistylesShadowRegistrySpec {
                             const jsi::Value* args,
                             size_t count);
     jsi::Value unlink(jsi::Runtime& rt,
+                            const jsi::Value& thisValue,
+                            const jsi::Value* args,
+                            size_t count);
+    jsi::Value flush(jsi::Runtime& rt,
                             const jsi::Value& thisValue,
                             const jsi::Value* args,
                             size_t count);
@@ -35,6 +40,7 @@ struct HybridShadowRegistry: public HybridUnistylesShadowRegistrySpec {
         registerHybrids(this, [](Prototype& prototype) {
             prototype.registerRawHybridMethod("link", 2, &HybridShadowRegistry::link);
             prototype.registerRawHybridMethod("unlink", 1, &HybridShadowRegistry::unlink);
+            prototype.registerRawHybridMethod("flush", 0, &HybridShadowRegistry::flush);
             prototype.registerRawHybridMethod("setScopedTheme", 1, &HybridShadowRegistry::setScopedTheme);
             prototype.registerRawHybridMethod("getScopedTheme", 0, &HybridShadowRegistry::getScopedTheme);
         });

--- a/src/components/ScopedTheme.tsx
+++ b/src/components/ScopedTheme.tsx
@@ -24,6 +24,11 @@ export const ScopedTheme: React.FunctionComponent<React.PropsWithChildren<ThemeP
         <Apply key='dispose' name={previousScopedTheme as keyof UnistylesThemes | undefined} />
     ]
 
+    useLayoutEffect(() => {
+        // this will affect only scoped styles as other styles are not yet mounted
+        UnistylesShadowRegistry.flush()
+    })
+
     return (
         <React.Fragment>
             {mappedChildren}

--- a/src/specs/ShadowRegistry/index.ts
+++ b/src/specs/ShadowRegistry/index.ts
@@ -9,6 +9,7 @@ interface ShadowRegistry extends UnistylesShadowRegistrySpec {
     // JSI
     link(node: ShadowNode, styles?: Array<Unistyle>): void,
     unlink(node: ShadowNode): void,
+    flush(): void,
     setScopedTheme(themeName?: string): void,
     getScopedTheme(): string | undefined
 }

--- a/src/web/shadowRegistry.ts
+++ b/src/web/shadowRegistry.ts
@@ -118,4 +118,6 @@ export class UnistylesShadowRegistry {
                 this.disposeMap.delete(hash)
             })
     }
+
+    flush = () => {}
 }


### PR DESCRIPTION
## Summary

Fixes #811 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new flush method to the shadow registry, enabling manual refresh of scoped styles after rendering.
- **Style**
	- Minor formatting improvement in theme-related logic for better code readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->