### PR TITLE
fix: prevent dangling reference in device event emitter by capturing eventType by value

### DIFF
--- a/cxx/UnistylesModel.cpp
+++ b/cxx/UnistylesModel.cpp
@@ -110,7 +110,7 @@ std::vector<std::pair<std::string, double>> UnistylesModel::toSortedBreakpointPa
 // ref: https://github.com/facebook/react-native/pull/43375
 // ref: https://github.com/facebook/react-native/blob/b5fd041917d197f256433a41a126f0dff767c429/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/TurboModule.cpp#L42
 void UnistylesModel::emitDeviceEvent(const std::string eventType, EventPayload payload) {
-    this->runOnJSThread([this, &eventType, payload = std::move(payload)](jsi::Runtime& rt){
+    this->runOnJSThread([this, eventType, payload = std::move(payload)](jsi::Runtime& rt){
         jsi::Value emitter = rt.global().getProperty(rt, "__rctDeviceEventEmitter");
 
         if (emitter.isUndefined()) {


### PR DESCRIPTION
## Summary

Fixes crash on some Android devices:

```
2   std::__ndk1::__throw_length_error[abi:nn180000] (stdexcept:243)
3   std::__ndk1::basic_string<T>::__throw_length_error[abi:nn180000] (string:2119)
8   hermes::vm::StringPrimitive::createEfficient (StringPrimitive.cpp:174)
12  facebook::jsi::String::createFromUtf8 (jsi.h:717)
13  UnistylesModel::emitDeviceEvent::lambda::operator() (UnistylesModel.cpp:127)
```

## Why

The lambda in `emitDeviceEvent` was capturing the `eventType` parameter by reference, but since `runOnJSThread` executes asynchronously, the `eventType` parameter went out of scope before the lambda executed 😓
