### PR TITLE
fix: update import paths by removing /src prefix in plugin files

### DIFF
--- a/plugin/index.js
+++ b/plugin/index.js
@@ -150,7 +150,7 @@ function addUnistylesImport(path2, state) {
     const newImport = t2.importDeclaration(
       [t2.importSpecifier(t2.identifier(localName), t2.identifier(name))],
       t2.stringLiteral(
-        state.opts.isLocal ? state.file.opts.filename?.split("react-native-unistyles").at(0)?.concat(`react-native-unistyles/components/native/${name}`) ?? "" : `react-native-unistyles/components/native/${name}`
+        state.opts.isLocal ? state.file.opts.filename?.split("react-native-unistyles").at(0)?.concat(`react-native-unistyles/src/components/native/${name}`) ?? "" : `react-native-unistyles/components/native/${name}`
       )
     );
     path2.node.body.unshift(newImport);

--- a/plugin/index.js
+++ b/plugin/index.js
@@ -150,7 +150,7 @@ function addUnistylesImport(path2, state) {
     const newImport = t2.importDeclaration(
       [t2.importSpecifier(t2.identifier(localName), t2.identifier(name))],
       t2.stringLiteral(
-        state.opts.isLocal ? state.file.opts.filename?.split("react-native-unistyles").at(0)?.concat(`react-native-unistyles/src/components/native/${name}`) ?? "" : `react-native-unistyles/components/native/${name}`
+        state.opts.isLocal ? state.file.opts.filename?.split("react-native-unistyles").at(0)?.concat(`react-native-unistyles/components/native/${name}`) ?? "" : `react-native-unistyles/components/native/${name}`
       )
     );
     path2.node.body.unshift(newImport);
@@ -166,7 +166,7 @@ function addUnistylesRequire(path2, state) {
       t2.variableDeclarator(
         t2.identifier(uniqueName),
         t2.callExpression(t2.identifier("require"), [
-          t2.stringLiteral(`react-native-unistyles/src/components/native/${componentName}`)
+          t2.stringLiteral(`react-native-unistyles/components/native/${componentName}`)
         ])
       )
     ]);

--- a/plugin/src/import.ts
+++ b/plugin/src/import.ts
@@ -34,7 +34,7 @@ export function addUnistylesImport(path: NodePath<t.Program>, state: UnistylesPl
         const newImport = t.importDeclaration(
             [t.importSpecifier(t.identifier(localName), t.identifier(name))],
             t.stringLiteral(state.opts.isLocal
-                ? state.file.opts.filename?.split('react-native-unistyles').at(0)?.concat(`react-native-unistyles/components/native/${name}`) ?? ''
+                ? state.file.opts.filename?.split('react-native-unistyles').at(0)?.concat(`react-native-unistyles/src/components/native/${name}`) ?? ''
                 : `react-native-unistyles/components/native/${name}`
             )
         )

--- a/plugin/src/import.ts
+++ b/plugin/src/import.ts
@@ -34,7 +34,7 @@ export function addUnistylesImport(path: NodePath<t.Program>, state: UnistylesPl
         const newImport = t.importDeclaration(
             [t.importSpecifier(t.identifier(localName), t.identifier(name))],
             t.stringLiteral(state.opts.isLocal
-                ? state.file.opts.filename?.split('react-native-unistyles').at(0)?.concat(`react-native-unistyles/src/components/native/${name}`) ?? ''
+                ? state.file.opts.filename?.split('react-native-unistyles').at(0)?.concat(`react-native-unistyles/components/native/${name}`) ?? ''
                 : `react-native-unistyles/components/native/${name}`
             )
         )
@@ -58,7 +58,7 @@ export function addUnistylesRequire(path: NodePath<t.Program>, state: UnistylesP
                 t.variableDeclarator(
                     t.identifier(uniqueName),
                     t.callExpression(t.identifier('require'), [
-                        t.stringLiteral(`react-native-unistyles/src/components/native/${componentName}`)
+                        t.stringLiteral(`react-native-unistyles/components/native/${componentName}`)
                     ])
                 )
             ])


### PR DESCRIPTION
## Summary

Fixes `console.warnings` from #829 
Babel plugin pointed to non-existing `export` in `package.json`.

It was workin, because by default there is a file-based fallback.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated import and require paths for native components to remove the unnecessary "/src" segment, ensuring consistency and simplifying path references. No changes to user-facing features or functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->