### PR TITLE
feat: support inverted adaptive themes

### DIFF
--- a/expo-example/app/(tabs)/index.tsx
+++ b/expo-example/app/(tabs)/index.tsx
@@ -1,68 +1,65 @@
 import React from 'react'
-import { Link } from 'expo-router'
-import { Pressable, View, Text } from 'react-native'
-import { StyleSheet, UnistylesRuntime } from 'react-native-unistyles'
+import { View, Text } from 'react-native'
+import { ScopedTheme, StyleSheet } from 'react-native-unistyles'
 
 export default function HomeScreen() {
-    styles.useVariants({
-        variant: 'blue'
-    })
-
     return (
-        <View style={styles.container(1)}>
-            <View style={styles.test}>
-                <Text style={styles.typography}>
-                    Hello world!
-                </Text>
-                <Link href="/explore" asChild>
-                    <Pressable style={styles.button}>
-                        <Text style={styles.typography}>
-                            Explore
-                        </Text>
-                    </Pressable>
-                </Link>
-                <Pressable onPress={() => UnistylesRuntime.getTheme()}>
+        <View style={styles.container}>
+            <ScopedTheme name="premium">
                     <Text style={styles.typography}>
-                        Press me
+                        Nested premium theme
                     </Text>
-                </Pressable>
-            </View>
+                    <ScopedTheme name="dark">
+                        <Text style={styles.typography}>
+                            Nested dark theme
+                        </Text>
+                    </ScopedTheme>
+                </ScopedTheme>
+            <ScopedTheme invertedAdaptive>
+                <View style={styles.box}>
+                    <Text style={styles.typography}>
+                        This box has an accent color, so it should be pink in light mode and red in dark mode
+                    </Text>
+                </View>
+                <Text style={styles.typography}>
+                    This text has a background color, so it should be dark for light mode and light for dark mode
+                </Text>
+                <ScopedTheme name="premium">
+                    <Text style={styles.typography}>
+                        Nested premium theme
+                    </Text>
+                    <ScopedTheme name="light">
+                        <Text style={styles.typography}>
+                            Nested light theme
+                        </Text>
+                    </ScopedTheme>
+                </ScopedTheme>
+                <Text style={styles.typography}>
+                    Again scoped theme with invertedAdaptive
+                </Text>
+            </ScopedTheme>
         </View>
     )
 }
 
 const styles = StyleSheet.create(theme => ({
-    container: (flex: number) => ({
-        flex,
+    container: {
+        flex: 1,
         justifyContent: 'center',
         alignItems: 'center',
+        paddingHorizontal: 16,
+        gap: 12,
         backgroundColor: theme.colors.backgroundColor
-    }),
+    },
     typography: {
-        fontSize: 20,
-        fontWeight: 'bold',
-        color: theme.colors.typography
+        fontSize: 12,
+        textAlign: 'center',
+        color: theme.colors.backgroundColor
     },
-    test: {
-        width: '100%',
-        variants: {
-            variant: {
-                red: {
-                    backgroundColor: 'red'
-                },
-                blue: {
-                    backgroundColor: 'blue'
-                }
-            }
-        }
-    },
-    button: {
-        backgroundColor: theme.colors.aloes,
-        padding: 10,
-        borderRadius: 8,
-        height: 60,
-        justifyContent: 'center',
-        alignItems: 'center',
-        width: '100%'
+    box: {
+        width: 100,
+        height: 100,
+        padding: 5,
+        backgroundColor: theme.colors.accent
     }
 }))

--- a/src/components/AdaptiveTheme.tsx
+++ b/src/components/AdaptiveTheme.tsx
@@ -1,9 +1,9 @@
 import React, { useLayoutEffect } from 'react'
 import type { PropsWithChildren } from 'react'
 import { useUnistyles } from '../core'
-import { ApplyScopedTheme } from './ApplyScopedTheme'
 import type { UnistylesThemes } from '../global'
 import { UnistylesShadowRegistry } from '../specs'
+import { ApplyScopedTheme } from './ApplyScopedTheme'
 
 interface AdaptiveThemeProps extends PropsWithChildren {
     previousScopedTheme?: string

--- a/src/components/AdaptiveTheme.tsx
+++ b/src/components/AdaptiveTheme.tsx
@@ -1,0 +1,34 @@
+import React, { useLayoutEffect } from 'react'
+import type { PropsWithChildren } from 'react'
+import { useUnistyles } from '../core'
+import { ApplyScopedTheme } from './ApplyScopedTheme'
+import type { UnistylesThemes } from '../global'
+import { UnistylesShadowRegistry } from '../specs'
+
+interface AdaptiveThemeProps extends PropsWithChildren {
+    previousScopedTheme?: string
+}
+
+export const AdaptiveTheme: React.FunctionComponent<AdaptiveThemeProps> = ({
+    children,
+    previousScopedTheme
+}) => {
+    const { rt } = useUnistyles()
+    const name = (rt.themeName === 'dark' ? 'light' : 'dark') as keyof UnistylesThemes
+    const mappedChildren = [
+        <ApplyScopedTheme key={name} name={name} />,
+        children,
+        <ApplyScopedTheme key='dispose' name={previousScopedTheme as keyof UnistylesThemes | undefined} />
+    ]
+
+    useLayoutEffect(() => {
+        // this will affect only scoped styles as other styles are not yet mounted
+        UnistylesShadowRegistry.flush()
+    })
+
+    return (
+        <React.Fragment key={name}>
+            {mappedChildren}
+        </React.Fragment>
+    )
+}

--- a/src/components/ApplyScopedTheme.tsx
+++ b/src/components/ApplyScopedTheme.tsx
@@ -1,0 +1,17 @@
+import { useLayoutEffect } from 'react'
+import type { UnistylesThemes } from '../global'
+import { UnistylesShadowRegistry } from '../specs'
+
+type ApplyScopedThemeProps = {
+    name?: keyof UnistylesThemes
+}
+
+export const ApplyScopedTheme: React.FunctionComponent<ApplyScopedThemeProps> = ({ name }) => {
+    UnistylesShadowRegistry.setScopedTheme(name)
+
+    useLayoutEffect(() => {
+        UnistylesShadowRegistry.setScopedTheme(name)
+    })
+
+    return null
+}

--- a/src/components/NamedTheme.tsx
+++ b/src/components/NamedTheme.tsx
@@ -1,8 +1,8 @@
 import React, { useLayoutEffect } from 'react'
 import type { PropsWithChildren } from 'react'
 import type { UnistylesThemes } from '../global'
-import { ApplyScopedTheme } from './ApplyScopedTheme'
 import { UnistylesShadowRegistry } from '../specs'
+import { ApplyScopedTheme } from './ApplyScopedTheme'
 
 interface NamedThemeProps extends PropsWithChildren {
     name: keyof UnistylesThemes,

--- a/src/components/NamedTheme.tsx
+++ b/src/components/NamedTheme.tsx
@@ -1,0 +1,33 @@
+import React, { useLayoutEffect } from 'react'
+import type { PropsWithChildren } from 'react'
+import type { UnistylesThemes } from '../global'
+import { ApplyScopedTheme } from './ApplyScopedTheme'
+import { UnistylesShadowRegistry } from '../specs'
+
+interface NamedThemeProps extends PropsWithChildren {
+    name: keyof UnistylesThemes,
+    previousScopedTheme?: string
+}
+
+export const NamedTheme: React.FunctionComponent<NamedThemeProps> = ({
+    name,
+    children,
+    previousScopedTheme
+}) => {
+    const mappedChildren = [
+        <ApplyScopedTheme key={name} name={name} />,
+        children,
+        <ApplyScopedTheme key='dispose' name={previousScopedTheme as keyof UnistylesThemes | undefined} />
+    ]
+
+    useLayoutEffect(() => {
+        // this will affect only scoped styles as other styles are not yet mounted
+        UnistylesShadowRegistry.flush()
+    })
+
+    return (
+        <React.Fragment>
+            {mappedChildren}
+        </React.Fragment>
+    )
+}


### PR DESCRIPTION
## Summary

Add support for inverted adaptiveThemes.

API:

```tsx
<ScopedTheme invertedAdaptive>
    components here will be light in dark mode and dark in light mode
</ScopedTheme>
```

Checklist:
- [x] Add mobile support
- [ ] Add web support
- [ ] Tests / docs