### PR TITLE
feat: add box-shadow string parsing support for style objects

### DIFF
--- a/cxx/parser/Parser.cpp
+++ b/cxx/parser/Parser.cpp
@@ -881,6 +881,14 @@ jsi::Value parser::Parser::parseSecondLevel(jsi::Runtime &rt, Unistyle::Shared u
     jsi::Object parsedStyle = jsi::Object(rt);
 
     helpers::enumerateJSIObject(rt, nestedObjectStyle, [&](const std::string& propertyName, jsi::Value& propertyValue){
+        // special case as we need to convert it to jsi::Array<jsi::Object>
+        // possible with variants and compoundVariants
+        if (propertyName == "boxShadow" && propertyValue.isString()) {
+            parsedStyle.setProperty(rt, jsi::PropNameID::forUtf8(rt, propertyName), parseBoxShadowString(rt, propertyValue.asString(rt).utf8(rt)));
+
+            return;
+        }
+
         // primitives, bool is possible for boxShadow inset
         if (propertyValue.isString() || propertyValue.isNumber() || propertyValue.isUndefined() || propertyValue.isNull() || propertyValue.isBool()) {
             parsedStyle.setProperty(rt, propertyName.c_str(), propertyValue);


### PR DESCRIPTION
## Summary

Fixes #841 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of the "boxShadow" property in nested style objects, ensuring string values are now properly processed and converted for consistent rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->