### PR TITLE
feat: remove react-native-gesture-handler from auto-processed paths

### DIFF
--- a/docs/src/content/docs/v3/other/babel-plugin.mdx
+++ b/docs/src/content/docs/v3/other/babel-plugin.mdx
@@ -295,7 +295,7 @@ Within these paths, we will replace `react-native` imports with `react-native-un
 Defaults to:
 
 ```ts
-['react-native-reanimated/src/component', 'react-native-gesture-handler/src/components']
+['react-native-reanimated/src/component']
 ```
 
 #### `debug`

--- a/docs/src/content/docs/v3/references/3rd-party-views.mdx
+++ b/docs/src/content/docs/v3/references/3rd-party-views.mdx
@@ -17,7 +17,7 @@ import Seo from '../../../../components/Seo.astro'
 This is our decision algorithm to ensure best practices for your app.
 :::
 
-1. If you're using `react-native`, `react-native-reanimated`, or `react-native-gesture-handler` components with `style` prop, avoid doing anything. It will work out of the box.
+1. If you're using `react-native` or `react-native-reanimated` components with `style` prop, avoid doing anything. It will work out of the box.
 
 2. For `react-native` components with `contentContainerStyle` prop, you can use the [withUnistyles](/v3/references/with-unistyles) factory. Wrapping your component in `withUnistyles` will [auto map](/v3/references/with-unistyles#auto-mapping-for-style-and-contentcontainerstyle-props) `contentContainerStyle` prop.
 

--- a/docs/src/content/docs/v3/references/use-unistyles.mdx
+++ b/docs/src/content/docs/v3/references/use-unistyles.mdx
@@ -23,7 +23,7 @@ Follow our [decision algorithm](/v3/references/3rd-party-views) to learn when to
 
 ### When to use it?
 
-If you're using `react-native`, `react-native-reanimated`, or `react-native-gesture-handler` components, you should avoid this hook. Unistyles updates these views via the ShadowTree without causing **any re-renders**.
+If you're using `react-native`, or `react-native-reanimated` components, you should avoid this hook. Unistyles updates these views via the ShadowTree without causing **any re-renders**.
 
 Consider using this hook only if:
 - You need to update a view in a third-party library like `react-native-blurhash`

--- a/plugin/index.d.ts
+++ b/plugin/index.d.ts
@@ -104,7 +104,7 @@ export interface UnistylesPluginOptions {
     * Defaults to:
     *
     * ```ts
-    * ['react-native-reanimated/src/component', 'react-native-gesture-handler/src/components']
+    * ['react-native-reanimated/src/component']
     * ```
     */
     autoProcessPaths?: Array<string>,

--- a/plugin/index.js
+++ b/plugin/index.js
@@ -60,10 +60,7 @@ var REACT_NATIVE_COMPONENT_NAMES = [
 ];
 var REPLACE_WITH_UNISTYLES_PATHS = [
   "react-native-reanimated/src/component",
-  "react-native-reanimated/lib/module/component",
-  "react-native-gesture-handler/lib/module/components",
-  "react-native-gesture-handler/lib/commonjs/components",
-  "react-native-gesture-handler/src/components"
+  "react-native-reanimated/lib/module/component"
 ];
 var REPLACE_WITH_UNISTYLES_EXOTIC_PATHS = [];
 var NATIVE_COMPONENTS_PATHS = {

--- a/plugin/src/consts.ts
+++ b/plugin/src/consts.ts
@@ -29,10 +29,7 @@ export const REACT_NATIVE_COMPONENT_NAMES = [
  */
 export const REPLACE_WITH_UNISTYLES_PATHS = [
     'react-native-reanimated/src/component',
-    'react-native-reanimated/lib/module/component',
-    'react-native-gesture-handler/lib/module/components',
-    'react-native-gesture-handler/lib/commonjs/components',
-    'react-native-gesture-handler/src/components'
+    'react-native-reanimated/lib/module/component'
 ]
 
 /**

--- a/repack-plugin/index.js
+++ b/repack-plugin/index.js
@@ -54,10 +54,7 @@ var REACT_NATIVE_COMPONENT_NAMES = [
 ];
 var REPLACE_WITH_UNISTYLES_PATHS = [
   "react-native-reanimated/src/component",
-  "react-native-reanimated/lib/module/component",
-  "react-native-gesture-handler/lib/module/components",
-  "react-native-gesture-handler/lib/commonjs/components",
-  "react-native-gesture-handler/src/components"
+  "react-native-reanimated/lib/module/component"
 ];
 
 // repack-plugin/src/loader.ts


### PR DESCRIPTION
## Summary

Remove `react-native-gesture-handler` from babel auto-processed paths.  
This fixes strange behavior in Storybook (#829).

Also, it doesn't make sense to add `style` props to these components. Initially, I thought it was a good idea, as we could avoid re-renders for Pressables. However, the underlying implementation points to native views, so it won't work without `withUnistyles`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated documentation to remove references to `react-native-gesture-handler` from supported components and configuration examples.
  - Clarified that only `react-native` and `react-native-reanimated` components are supported out of the box.

- **Chores**
  - Updated default configuration and internal arrays to exclude all `react-native-gesture-handler` paths, reducing supported auto-processing to `react-native-reanimated` components only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->