### PR TITLE
fix: use content view instead of decorView to get initial window insets on Android

### DIFF
--- a/android/src/main/java/com/unistyles/NativePlatform+insets.kt
+++ b/android/src/main/java/com/unistyles/NativePlatform+insets.kt
@@ -166,7 +166,7 @@ class NativePlatformInsets(
 
     fun stopInsetsListener() {
         reactContext.currentActivity?.let { activity ->
-            activity.window?.decorView?.let { view ->
+            activity.findViewById<View>(android.R.id.content)?.let { view ->
                 ViewCompat.setOnApplyWindowInsetsListener(view, null)
             }
         }


### PR DESCRIPTION
## Summary

Maybe fixes issue #859 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved accuracy in retrieving window insets on Android devices, ensuring better layout handling across different screens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->