### PR TITLE
feat: add CI type checks to examples

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,3 +39,50 @@ jobs:
 
       - name: Run tests
         run: yarn test
+  lint-example:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: ./example
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: yarn
+
+      - name: Install
+        run: yarn
+
+      - name: Type check
+        run: yarn tsc
+  lint-expo-example:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: ./expo-example
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: yarn
+
+      - name: Install
+        run: yarn
+
+      - name: Type check
+        run: yarn tsc
+
+
+


### PR DESCRIPTION
## Summary

Adds `yarn tsc` runs for both `example` and `expo-example` projects on github actions CI

Note that both are failing. The errors match what we're seeing in our app project on `rc5`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved continuous integration by adding separate linting and type-checking jobs for the example projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->