### PR TITLE
feat: scoped themes

### DIFF
--- a/cxx/hybridObjects/HybridUnistylesRuntime.cpp
+++ b/cxx/hybridObjects/HybridUnistylesRuntime.cpp
@@ -20,8 +20,15 @@ Dimensions HybridUnistylesRuntime::getScreen() {
 };
 
 std::optional<std::string> HybridUnistylesRuntime::getThemeName() {
-    auto& state = core::UnistylesRegistry::get().getState(*_rt);
-
+    auto& registry = core::UnistylesRegistry::get();
+    auto maybeScopedTheme = registry.getScopedTheme();
+    
+    if (maybeScopedTheme.has_value()) {
+        return maybeScopedTheme.value();
+    }
+    
+    auto& state = registry.getState(*_rt);
+    
     return state.getCurrentThemeName();
 };
 

--- a/expo-example/app/(tabs)/index.tsx
+++ b/expo-example/app/(tabs)/index.tsx
@@ -24,13 +24,16 @@ export default function HomeScreen() {
     return (
         <View style={styles.container}>
             <ScopedText prefix="Root" expected="adaptive" />
-            <ScopedTheme name={count % 2 === 0 ? 'dark' : 'light'}>
+            <ScopedTheme name={count % 2 === 0 ? 'dark' as const : 'light' as const}>
                 <ScopedText prefix="ScopedText" expected={count % 2 === 0 ? 'dark' : 'light'} />
             </ScopedTheme>
             <ScopedTheme name="light">
                 <ScopedText prefix="ScopedText" expected="light" />
                 <ScopedTheme name="premium">
                     <ScopedText prefix="ScopedText" expected="premium" />
+                    <ScopedTheme reset>
+                        <ScopedText prefix="ResetText" expected="adaptive" />
+                    </ScopedTheme>
                 </ScopedTheme>
             </ScopedTheme>
             <ScopedTheme invertedAdaptive>

--- a/expo-example/app/(tabs)/index.tsx
+++ b/expo-example/app/(tabs)/index.tsx
@@ -1,66 +1,68 @@
 import React from 'react'
-import { View, Text, Button } from 'react-native'
-import { ScopedTheme, StyleSheet, useUnistyles, withUnistyles } from 'react-native-unistyles'
-
-const StyledText = withUnistyles(Text, (theme, rt) => ({
-    children: rt.themeName
-}))
-
-const ScopedText = ({ prefix, expected }: { prefix: string; expected: string }) => {
-    const { rt } = useUnistyles()
-
-    rt.isPortrait
-
-    return (
-        <Text style={{ color: 'gray', fontSize: 20 }}>
-            {prefix}: I'm {rt.themeName} ({expected})
-        </Text>
-    )
-}
+import { Link } from 'expo-router'
+import { Pressable, View, Text } from 'react-native'
+import { StyleSheet, UnistylesRuntime } from 'react-native-unistyles'
 
 export default function HomeScreen() {
-    const [count, setCount] = React.useState(0)
+    styles.useVariants({
+        variant: 'blue'
+    })
 
     return (
-        <View style={styles.container}>
-            <ScopedText prefix="Root" expected="adaptive" />
-            <ScopedTheme name={count % 2 === 0 ? 'dark' as const : 'light' as const}>
-                <ScopedText prefix="ScopedText" expected={count % 2 === 0 ? 'dark' : 'light'} />
-            </ScopedTheme>
-            <ScopedTheme name="light">
-                <ScopedText prefix="ScopedText" expected="light" />
-                <ScopedTheme name="premium">
-                    <ScopedText prefix="ScopedText" expected="premium" />
-                    <ScopedTheme reset>
-                        <ScopedText prefix="ResetText" expected="adaptive" />
-                    </ScopedTheme>
-                </ScopedTheme>
-            </ScopedTheme>
-            <ScopedTheme invertedAdaptive>
-                <ScopedText prefix="invertedAdaptive 1" expected="inverted-adaptive" />
-                <ScopedTheme invertedAdaptive>
-                    <ScopedText prefix="invertedAdaptive 2" expected="inverted-adaptive" />
-                </ScopedTheme>
-            </ScopedTheme>
-            <ScopedText prefix="NextComponent" expected="adaptive" />
-            <ScopedTheme invertedAdaptive>
-                <StyledText style={{ color: 'red' }} />
-            </ScopedTheme>
-            <Button title="Increment" onPress={() => setCount(count + 1)} />
+        <View style={styles.container(1)}>
+            <View style={styles.test}>
+                <Text style={styles.typography}>
+                    Hello world!
+                </Text>
+                <Link href="/explore" asChild>
+                    <Pressable style={styles.button}>
+                        <Text style={styles.typography}>
+                            Explore
+                        </Text>
+                    </Pressable>
+                </Link>
+                <Pressable onPress={() => UnistylesRuntime.getTheme()}>
+                    <Text style={styles.typography}>
+                        Press me
+                    </Text>
+                </Pressable>
+            </View>
         </View>
     )
 }
 
 const styles = StyleSheet.create(theme => ({
-    container: {
-        flex: 1,
+    container: (flex: number) => ({
+        flex,
         justifyContent: 'center',
-        paddingHorizontal: 20,
+        alignItems: 'center',
         backgroundColor: theme.colors.backgroundColor
-    },
+    }),
     typography: {
         fontSize: 20,
         fontWeight: 'bold',
         color: theme.colors.typography
+    },
+    test: {
+        width: '100%',
+        variants: {
+            variant: {
+                red: {
+                    backgroundColor: 'red'
+                },
+                blue: {
+                    backgroundColor: 'blue'
+                }
+            }
+        }
+    },
+    button: {
+        backgroundColor: theme.colors.aloes,
+        padding: 10,
+        borderRadius: 8,
+        height: 60,
+        justifyContent: 'center',
+        alignItems: 'center',
+        width: '100%'
     }
 }))

--- a/expo-example/app/(tabs)/index.tsx
+++ b/expo-example/app/(tabs)/index.tsx
@@ -1,21 +1,17 @@
 import React from 'react'
 import { View, Text } from 'react-native'
-import { ScopedTheme, StyleSheet, UnistylesRuntime } from 'react-native-unistyles'
+import { ScopedTheme, StyleSheet, useUnistyles, withUnistyles } from 'react-native-unistyles'
 
-const ScopedText = ({ prefix }: { prefix: string }) => {
-    const themeName = UnistylesRuntime.themeName
+const StyledText = withUnistyles(Text, (theme, rt) => ({
+    children: rt.themeName
+}))
+
+const ScopedText = ({ prefix, expected }: { prefix: string; expected: string }) => {
+    const { rt } = useUnistyles()
 
     return (
         <Text style={{ color: 'gray', fontSize: 20 }}>
-            {prefix}: I'm {themeName}
-        </Text>
-    )
-}
-
-const NextComponent = () => {
-    return (
-        <Text style={{ color: 'gray', fontSize: 20 }}>
-            NextComponent: I'm {UnistylesRuntime.themeName}
+            {prefix}: I'm {rt.themeName} ({expected})
         </Text>
     )
 }
@@ -23,23 +19,26 @@ const NextComponent = () => {
 export default function HomeScreen() {
     return (
         <View style={styles.container}>
-            <ScopedText prefix="Root" />
+            <ScopedText prefix="Root" expected="adaptive" />
             <ScopedTheme name="dark">
-                <ScopedText prefix="ScopedText" />
+                <ScopedText prefix="ScopedText" expected="dark" />
             </ScopedTheme>
             <ScopedTheme name="light">
-                <ScopedText prefix="ScopedText" />
+                <ScopedText prefix="ScopedText" expected="light" />
                 <ScopedTheme name="premium">
-                    <ScopedText prefix="ScopedText" />
+                    <ScopedText prefix="ScopedText" expected="premium" />
                 </ScopedTheme>
             </ScopedTheme>
             <ScopedTheme invertedAdaptive>
-                <ScopedText prefix="invertedAdaptive 1" />
+                <ScopedText prefix="invertedAdaptive 1" expected="inverted-adaptive" />
                 <ScopedTheme invertedAdaptive>
-                    <ScopedText prefix="invertedAdaptive 2" />
+                    <ScopedText prefix="invertedAdaptive 2" expected="inverted-adaptive" />
                 </ScopedTheme>
             </ScopedTheme>
-            <NextComponent />
+            <ScopedText prefix="NextComponent" expected="adaptive" />
+            <ScopedTheme invertedAdaptive>
+                <StyledText style={{ color: 'red' }} />
+            </ScopedTheme>
         </View>
     )
 }
@@ -48,7 +47,7 @@ const styles = StyleSheet.create(theme => ({
     container: {
         flex: 1,
         justifyContent: 'center',
-        alignItems: 'center',
+        paddingHorizontal: 20,
         backgroundColor: theme.colors.backgroundColor
     },
     typography: {

--- a/expo-example/app/(tabs)/index.tsx
+++ b/expo-example/app/(tabs)/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { View, Text } from 'react-native'
+import { View, Text, Button } from 'react-native'
 import { ScopedTheme, StyleSheet, useUnistyles, withUnistyles } from 'react-native-unistyles'
 
 const StyledText = withUnistyles(Text, (theme, rt) => ({
@@ -9,6 +9,8 @@ const StyledText = withUnistyles(Text, (theme, rt) => ({
 const ScopedText = ({ prefix, expected }: { prefix: string; expected: string }) => {
     const { rt } = useUnistyles()
 
+    rt.isPortrait
+
     return (
         <Text style={{ color: 'gray', fontSize: 20 }}>
             {prefix}: I'm {rt.themeName} ({expected})
@@ -17,11 +19,13 @@ const ScopedText = ({ prefix, expected }: { prefix: string; expected: string }) 
 }
 
 export default function HomeScreen() {
+    const [count, setCount] = React.useState(0)
+
     return (
         <View style={styles.container}>
             <ScopedText prefix="Root" expected="adaptive" />
-            <ScopedTheme name="dark">
-                <ScopedText prefix="ScopedText" expected="dark" />
+            <ScopedTheme name={count % 2 === 0 ? 'dark' : 'light'}>
+                <ScopedText prefix="ScopedText" expected={count % 2 === 0 ? 'dark' : 'light'} />
             </ScopedTheme>
             <ScopedTheme name="light">
                 <ScopedText prefix="ScopedText" expected="light" />
@@ -39,6 +43,7 @@ export default function HomeScreen() {
             <ScopedTheme invertedAdaptive>
                 <StyledText style={{ color: 'red' }} />
             </ScopedTheme>
+            <Button title="Increment" onPress={() => setCount(count + 1)} />
         </View>
     )
 }

--- a/expo-example/app/(tabs)/index.tsx
+++ b/expo-example/app/(tabs)/index.tsx
@@ -1,68 +1,59 @@
 import React from 'react'
-import { Link } from 'expo-router'
-import { Pressable, View, Text } from 'react-native'
-import { StyleSheet, UnistylesRuntime } from 'react-native-unistyles'
+import { View, Text } from 'react-native'
+import { ScopedTheme, StyleSheet, UnistylesRuntime } from 'react-native-unistyles'
 
-export default function HomeScreen() {
-    styles.useVariants({
-        variant: 'blue'
-    })
+const ScopedText = ({ prefix }: { prefix: string }) => {
+    const themeName = UnistylesRuntime.themeName
 
     return (
-        <View style={styles.container(1)}>
-            <View style={styles.test}>
-                <Text style={styles.typography}>
-                    Hello world!
-                </Text>
-                <Link href="/explore" asChild>
-                    <Pressable style={styles.button}>
-                        <Text style={styles.typography}>
-                            Explore
-                        </Text>
-                    </Pressable>
-                </Link>
-                <Pressable onPress={() => UnistylesRuntime.getTheme()}>
-                    <Text style={styles.typography}>
-                        Press me
-                    </Text>
-                </Pressable>
-            </View>
+        <Text style={{ color: 'gray', fontSize: 20 }}>
+            {prefix}: I'm {themeName}
+        </Text>
+    )
+}
+
+const NextComponent = () => {
+    return (
+        <Text style={{ color: 'gray', fontSize: 20 }}>
+            NextComponent: I'm {UnistylesRuntime.themeName}
+        </Text>
+    )
+}
+
+export default function HomeScreen() {
+    return (
+        <View style={styles.container}>
+            <ScopedText prefix="Root" />
+            <ScopedTheme name="dark">
+                <ScopedText prefix="ScopedText" />
+            </ScopedTheme>
+            <ScopedTheme name="light">
+                <ScopedText prefix="ScopedText" />
+                <ScopedTheme name="premium">
+                    <ScopedText prefix="ScopedText" />
+                </ScopedTheme>
+            </ScopedTheme>
+            <ScopedTheme invertedAdaptive>
+                <ScopedText prefix="invertedAdaptive 1" />
+                <ScopedTheme invertedAdaptive>
+                    <ScopedText prefix="invertedAdaptive 2" />
+                </ScopedTheme>
+            </ScopedTheme>
+            <NextComponent />
         </View>
     )
 }
 
 const styles = StyleSheet.create(theme => ({
-    container: (flex: number) => ({
-        flex,
+    container: {
+        flex: 1,
         justifyContent: 'center',
         alignItems: 'center',
         backgroundColor: theme.colors.backgroundColor
-    }),
+    },
     typography: {
         fontSize: 20,
         fontWeight: 'bold',
         color: theme.colors.typography
-    },
-    test: {
-        width: '100%',
-        variants: {
-            variant: {
-                red: {
-                    backgroundColor: 'red'
-                },
-                blue: {
-                    backgroundColor: 'blue'
-                }
-            }
-        }
-    },
-    button: {
-        backgroundColor: theme.colors.aloes,
-        padding: 10,
-        borderRadius: 8,
-        height: 60,
-        justifyContent: 'center',
-        alignItems: 'center',
-        width: '100%'
     }
 }))

--- a/src/components/AdaptiveTheme.tsx
+++ b/src/components/AdaptiveTheme.tsx
@@ -14,7 +14,7 @@ export const AdaptiveTheme: React.FunctionComponent<AdaptiveThemeProps> = ({
     previousScopedTheme
 }) => {
     const { rt } = useUnistyles()
-    const name = (rt.themeName === 'dark' ? 'light' : 'dark') as keyof UnistylesThemes
+    const name = (rt.colorScheme === 'dark' ? 'light' : 'dark') as keyof UnistylesThemes
     const mappedChildren = [
         <ApplyScopedTheme key={name} name={name} />,
         children,

--- a/src/components/NamedTheme.tsx
+++ b/src/components/NamedTheme.tsx
@@ -5,7 +5,7 @@ import { UnistylesShadowRegistry } from '../specs'
 import { ApplyScopedTheme } from './ApplyScopedTheme'
 
 interface NamedThemeProps extends PropsWithChildren {
-    name: keyof UnistylesThemes,
+    name: keyof UnistylesThemes | undefined,
     previousScopedTheme?: string
 }
 
@@ -15,7 +15,7 @@ export const NamedTheme: React.FunctionComponent<NamedThemeProps> = ({
     previousScopedTheme
 }) => {
     const mappedChildren = [
-        <ApplyScopedTheme key={name} name={name} />,
+        <ApplyScopedTheme key='apply' name={name} />,
         children,
         <ApplyScopedTheme key='dispose' name={previousScopedTheme as keyof UnistylesThemes | undefined} />
     ]

--- a/src/components/ScopedTheme.tsx
+++ b/src/components/ScopedTheme.tsx
@@ -10,12 +10,12 @@ type ThemeProps = {
     reset?: never
 } | {
     name?: never,
-    invertedAdaptive: true,
+    invertedAdaptive: boolean,
     reset?: never
 } | {
     name?: never,
     invertedAdaptive?: never,
-    reset: true
+    reset: boolean
 }
 
 export const ScopedTheme: React.FunctionComponent<React.PropsWithChildren<ThemeProps>> = ({
@@ -26,20 +26,18 @@ export const ScopedTheme: React.FunctionComponent<React.PropsWithChildren<ThemeP
 }) => {
     const hasAdaptiveThemes = UnistylesRuntime.hasAdaptiveThemes
     const isAdaptiveTheme = invertedAdaptive && hasAdaptiveThemes
-
-    if (!invertedAdaptive && !name && !reset) {
-        if (__DEV__) {
-            console.error('ScopedTheme: name, reset or invertedAdaptive must be provided')
-        }
-
-        return null
-    }
-
     const previousScopedTheme = UnistylesShadowRegistry.getScopedTheme()
 
     switch (true) {
-        case invertedAdaptive && !hasAdaptiveThemes:
-            return children
+        case name !== undefined:
+            return (
+                <NamedTheme
+                    name={name as keyof UnistylesThemes}
+                    previousScopedTheme={previousScopedTheme}
+                >
+                    {children}
+                </NamedTheme>
+            )
         case isAdaptiveTheme:
             return (
                 <AdaptiveTheme previousScopedTheme={previousScopedTheme}>
@@ -55,16 +53,8 @@ export const ScopedTheme: React.FunctionComponent<React.PropsWithChildren<ThemeP
                     {children}
                 </NamedTheme>
             )
-        case name !== undefined:
-            return (
-                <NamedTheme
-                    name={name as keyof UnistylesThemes}
-                    previousScopedTheme={previousScopedTheme}
-                >
-                    {children}
-                </NamedTheme>
-            )
+        case invertedAdaptive && !hasAdaptiveThemes:
         default:
-            return null
+            return children
     }
 }

--- a/src/components/ScopedTheme.tsx
+++ b/src/components/ScopedTheme.tsx
@@ -53,7 +53,6 @@ export const ScopedTheme: React.FunctionComponent<React.PropsWithChildren<ThemeP
                     {children}
                 </NamedTheme>
             )
-        case invertedAdaptive && !hasAdaptiveThemes:
         default:
             return children
     }

--- a/src/core/useProxifiedUnistyles/listener.native.ts
+++ b/src/core/useProxifiedUnistyles/listener.native.ts
@@ -10,7 +10,9 @@ export const listener = ({ dependencies, updateTheme, updateRuntime }: ListenerP
         }
 
         if (changedDependencies.some((dependency: UnistyleDependency) => dependencies.includes(dependency))) {
-            updateRuntime()
+            const hasThemeNameChange = changedDependencies.includes(UnistyleDependency.ThemeName)
+
+            updateRuntime(hasThemeNameChange)
         }
     })
 

--- a/src/core/useProxifiedUnistyles/listener.ts
+++ b/src/core/useProxifiedUnistyles/listener.ts
@@ -4,7 +4,7 @@ import type { ListenerProps } from './types'
 
 export const listener = ({ dependencies, updateTheme, updateRuntime }: ListenerProps) => {
     const disposeTheme = unistyles.services.listener.addListeners(dependencies.filter(dependency => dependency === UnistyleDependency.Theme), updateTheme)
-    const disposeRuntime = unistyles.services.listener.addListeners(dependencies.filter(dependency => dependency !== UnistyleDependency.Theme), updateRuntime)
+    const disposeRuntime = unistyles.services.listener.addListeners(dependencies.filter(dependency => dependency !== UnistyleDependency.Theme), dependency => updateRuntime(dependency === UnistyleDependency.ThemeName))
 
     return () => {
         disposeTheme()

--- a/src/core/useProxifiedUnistyles/types.ts
+++ b/src/core/useProxifiedUnistyles/types.ts
@@ -2,6 +2,6 @@ import type { UnistyleDependency } from '../../specs'
 
 export type ListenerProps = {
     updateTheme: VoidFunction,
-    updateRuntime: VoidFunction,
+    updateRuntime(themeNameChange: boolean): void,
     dependencies: Array<UnistyleDependency>
 }

--- a/src/core/useProxifiedUnistyles/useProxifiedUnistyles.ts
+++ b/src/core/useProxifiedUnistyles/useProxifiedUnistyles.ts
@@ -45,7 +45,13 @@ export const useProxifiedUnistyles = (forcedTheme?: UnistylesTheme) => {
 
                 setTheme(UnistylesRuntime.getTheme(scopedTheme))
             },
-            updateRuntime: () => runtimeChanged()
+            updateRuntime: (hasThemeNameChange: boolean) => {
+                if (hasThemeNameChange && scopedTheme) {
+                    return
+                }
+
+                runtimeChanged()
+            }
         })
     }
 

--- a/src/web/listener.ts
+++ b/src/web/listener.ts
@@ -1,16 +1,18 @@
 import { UnistyleDependency } from '../specs/NativePlatform'
 import type { UnistylesServices } from './types'
 
+type Listener = (dependency: UnistyleDependency) => void
+
 export class UnistylesListener {
     private isInitialized = false
-    private listeners = Array.from({ length: Object.keys(UnistyleDependency).length / 2 }, () => new Set<VoidFunction>())
-    private stylesheetListeners = Array.from({ length: Object.keys(UnistyleDependency).length / 2 }, () => new Set<VoidFunction>())
+    private listeners = Array.from({ length: Object.keys(UnistyleDependency).length / 2 }, () => new Set<Listener>())
+    private stylesheetListeners = Array.from({ length: Object.keys(UnistyleDependency).length / 2 }, () => new Set<Listener>())
 
     constructor(private services: UnistylesServices) {}
 
     emitChange = (dependency: UnistyleDependency) => {
-        this.stylesheetListeners[dependency]?.forEach(listener => listener())
-        this.listeners[dependency]?.forEach(listener => listener())
+        this.stylesheetListeners[dependency]?.forEach(listener => listener(dependency))
+        this.listeners[dependency]?.forEach(listener => listener(dependency))
     }
 
     initListeners = () => {
@@ -49,7 +51,7 @@ export class UnistylesListener {
         window.addEventListener('resize', () => this.emitChange(UnistyleDependency.Dimensions))
     }
 
-    addListeners = (dependencies: Array<UnistyleDependency>, listener: VoidFunction) => {
+    addListeners = (dependencies: Array<UnistyleDependency>, listener: Listener) => {
         dependencies.forEach(dependency => this.listeners[dependency]?.add(listener))
 
         return () => {
@@ -57,7 +59,7 @@ export class UnistylesListener {
         }
     }
 
-    addStylesheetListeners = (dependencies: Array<UnistyleDependency>, listener: VoidFunction) => {
+    addStylesheetListeners = (dependencies: Array<UnistyleDependency>, listener: Listener) => {
         dependencies.forEach(dependency => this.stylesheetListeners[dependency]?.add(listener))
 
         return () => {

--- a/src/web/runtime.ts
+++ b/src/web/runtime.ts
@@ -49,6 +49,12 @@ export class UnistylesRuntime {
     }
 
     get themeName() {
+        const scopedTheme = this.services.shadowRegistry.getScopedTheme()
+
+        if (scopedTheme) {
+            return scopedTheme
+        }
+
         if (this.services.state.hasAdaptiveThemes) {
             return schemeToTheme(this.colorScheme) as AppThemeName
         }


### PR DESCRIPTION
## Summary

Improve `ScopedThemes` API.

1. `UnistylesRuntime.themeName`, `useUnistyles` and `withUnistyles` takes in count scopedTheme

```tsx
const ScopedText = () => {
  const { rt } = useUnistyles()

  return (
    <Text style={styles.text}>
      I'm {rt.themeName}
    </Text>
  )
}

// JSX
<ScopedTheme name="light">
  <ScopedText /> // I'm light
  <ScopedTheme name="premium">
    <ScopedText /> // I'm premium
      <ScopedTheme name="dark">
        <ScopedText /> // I'm dark
      </ScopedTheme>
  </ScopedTheme>
</ScopedTheme>
```

3.  `reset` API

```tsx
<Text>I'm light!</Text>
<ScopedTheme name="dark">
    <Text>I'm dark!</Text>
    <ScopedTheme reset>
        <Text>I'm light!</Text>
    </ScopedTheme>
</ScopedTheme>
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added support for resetting the theme context, allowing themes to be cleared or reverted dynamically.
- **Improvements**
	- Enhanced theme selection logic to prioritize scoped themes when available, ensuring more accurate theme application.
	- Strengthened type safety and prop exclusivity for theme-related components, reducing potential misuse.
	- Improved synchronization and state management for scoped themes, resulting in more reliable theme updates.
- **Bug Fixes**
	- Fixed issues where alternate theme selection logic did not accurately reflect the current color scheme.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->