### PR TITLE
feat: SDK 35+ improve insets initialization on Android

### DIFF
--- a/android/src/main/java/com/unistyles/NativePlatform+android.kt
+++ b/android/src/main/java/com/unistyles/NativePlatform+android.kt
@@ -41,6 +41,7 @@ class NativePlatformAndroid(private val reactContext: ReactApplicationContext): 
     }
 
     override fun onHostResume() {
+        _insets.getInitialInsets(false)
         _insets.startInsetsListener()
     }
 


### PR DESCRIPTION
## Summary

Fixes #859


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved handling of initial window insets to ensure they are retrieved reliably when the app resumes.
- **Refactor**
  - Updated the logic for fetching and updating window insets for better efficiency and to prevent redundant operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->