### PR TITLE
feat: Android add support for 16 KB page size

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -45,7 +45,7 @@ android {
         minSdkVersion safeExtGet('minSdkVersion', 24)
         externalNativeBuild {
             cmake {
-                arguments "-DANDROID_STL=c++_shared"
+                arguments "-DANDROID_STL=c++_shared", "-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON"
                 abiFilters (*reactNativeArchitectures())
             }
         }


### PR DESCRIPTION
## Summary



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated Android build configuration to enable support for flexible page sizes in the native build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->