### PR TITLE
feat: add missing mocks for reanimated

### DIFF
--- a/expo-example/__tests__/__snapshots__/example.spec.tsx.snap
+++ b/expo-example/__tests__/__snapshots__/example.spec.tsx.snap
@@ -37,7 +37,7 @@ exports[`Example test should pass 1`] = `
         }
       }
     >
-      Hello world
+      Hello world!
     </Text>
     <View
       accessibilityState={

--- a/expo-example/package.json
+++ b/expo-example/package.json
@@ -43,7 +43,8 @@
   "jest": {
     "preset": "jest-expo",
     "setupFiles": [
-      "../src/mocks.ts"
+      "../src/mocks.ts",
+      "./unistyles.ts"
     ]
   },
   "private": true

--- a/src/mocks.ts
+++ b/src/mocks.ts
@@ -217,4 +217,27 @@ jest.mock('react-native-unistyles', () => {
     }
 })
 
+jest.mock('react-native-unistyles/reanimated', () => {
+    const unistyles = require('react-native-unistyles')
+    const mockedSharedValue = (value: any) => ({
+        value
+    })
 
+    return {
+        useAnimatedTheme: () => {
+            const theme = unistyles.useUnistyles().theme
+            const sharedTheme = mockedSharedValue(theme)
+
+            return sharedTheme
+        },
+        useAnimatedVariantColor: () => {
+            const fromValue = mockedSharedValue('#000000')
+            const toValue = mockedSharedValue('#FFFFFF')
+
+            return {
+                fromValue,
+                toValue
+            }
+        },
+    }
+})


### PR DESCRIPTION
## Summary

This PR mocks:
- `useAnimatedTheme`
- `useAnimatedVariantColor`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Extended Jest setup to include an additional setup file for improved test initialization.
  * Added new Jest mocks for animated theme and variant color hooks to enhance test coverage for animation-related features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->