### PR TITLE
chore: rename ruby script to something more unique

### DIFF
--- a/Unistyles.podspec
+++ b/Unistyles.podspec
@@ -1,5 +1,5 @@
 require "json"
-require_relative './get_rn_version.rb'
+require_relative './unistyles_get_rn_version.rb'
 
 package = JSON.parse(File.read(File.join(__dir__, "package.json")))
 
@@ -28,7 +28,7 @@ Pod::Spec.new do |s|
   ]
 
   if ENV["USE_FRAMEWORKS"]
-    RN_VERSION = get_rn_version(ENV['REACT_NATIVE_PATH']) || 999
+    RN_VERSION = unistyles_get_rn_version(ENV['REACT_NATIVE_PATH']) || 999
 
     s.dependency "React-Core"
     add_dependency(s, "React-jsinspector", :framework_name => "jsinspector_modern")

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "react-native.config.js",
     "Unistyles.podspec",
     "repack-plugin",
-    "get_rn_version.rb",
+    "unistyles_get_rn_version.rb",
     "!repack-plugin/__tests__",
     "!repack-plugin/src",
     "!repack-plugin/esbuild.js",

--- a/unistyles_get_rn_version.rb
+++ b/unistyles_get_rn_version.rb
@@ -1,6 +1,6 @@
 require 'json'
 
-def get_rn_version(rn_path)
+def unistyles_get_rn_version(rn_path)
     rn_path = rn_path || '../node_modules/react-native'
 
     maybe_rn_pkg_json = File.expand_path(File.join(rn_path, 'package.json'))


### PR DESCRIPTION
## Summary

Fixes #895 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated references to a Ruby script used for React Native version detection to use a new filename and function name.
  * Adjusted package configuration to include the renamed script.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->