### PR TITLE
Update unistyles_get_rn_version.rb

### DIFF
--- a/unistyles_get_rn_version.rb
+++ b/unistyles_get_rn_version.rb
@@ -5,12 +5,15 @@ def unistyles_get_rn_version(rn_path)
 
     maybe_rn_pkg_json = File.expand_path(File.join(rn_path, 'package.json'))
     maybe_local_rn_pkg_json = File.expand_path('./node_modules/react-native/package.json')
+    maybe_react_native_pkg_json = File.expand_path('../react-native/package.json')
 
     rn_pkg_json =
         if File.exist?(maybe_rn_pkg_json)
             maybe_rn_pkg_json
         elsif File.exist?(maybe_local_rn_pkg_json)
             maybe_local_rn_pkg_json
+        elsif File.exist?(maybe_react_native_pkg_json)
+            maybe_react_native_pkg_json
         else
             nil
         end


### PR DESCRIPTION
Could not locate the `package.json` file for React Native within the monorepo

## Summary

Currently:
<img width="1402" alt="Screenshot 2025-07-08 at 14 50 18" src="https://github.com/user-attachments/assets/765a4a4c-8638-4ba7-8a3e-c30cad5c7bd1" />

Expected:
<img width="1338" alt="Screenshot 2025-07-08 at 14 51 22" src="https://github.com/user-attachments/assets/374288d4-ec63-4bc8-bdee-36d5ba769262" />
