### PR TITLE
Line Height Number is preferrend over px

### DIFF
--- a/src/web/convert/style.ts
+++ b/src/web/convert/style.ts
@@ -54,7 +54,8 @@ const CSS_NUMBER_KEYS = new Set([
     'strokeMiterlimit',
     'strokeOpacity',
     'strokeWidth',
-    'aspectRatio'
+    'aspectRatio',
+    'lineHeight'
 ])
 
 const convertMap = {


### PR DESCRIPTION
## Summary

https://developer.mozilla.org/en-US/docs/Web/CSS/line-height

With px, most of the time you have to calculate the fontSize multiplied by line height you want to apply, where as number automatically does that. Atleast that's what I understood


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Numeric values for 'lineHeight' in styles are now correctly handled as unitless numbers instead of being converted to pixel values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->