### PR TITLE
fix: allow passing adaptiveThemes false with initialTheme

### DIFF
--- a/src/specs/StyleSheet/index.ts
+++ b/src/specs/StyleSheet/index.ts
@@ -8,7 +8,7 @@ import type { UnistylesStyleSheet as UnistylesStyleSheetSpec } from './Unistyles
 
 type UnistylesThemeSettings = {
     initialTheme: (() => keyof UnistylesThemes) | keyof UnistylesThemes
-    adaptiveThemes?: never
+    adaptiveThemes?: never | false
 } | {
     adaptiveThemes: boolean
     initialTheme?: never


### PR DESCRIPTION
## Summary
Allow passing `adaptiveThemes: false` alongside `initialTheme`

<img width="449" height="416" alt="image" src="https://github.com/user-attachments/assets/c1a7d395-0915-4f35-b9d8-1a6f6405dec2" />
<img width="1037" height="419" alt="image" src="https://github.com/user-attachments/assets/7e49b422-7dc1-4394-9fea-abde67a346d6" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated theme settings to allow more flexibility when specifying theme options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->