### PR TITLE
fix: map autoProcessPaths values to platform path

### DIFF
--- a/plugin/index.js
+++ b/plugin/index.js
@@ -729,7 +729,7 @@ function index_default() {
           if (state.file.opts.root === appRoot) {
             throw new Error("Unistyles \u{1F984}: Root option can't resolve to project root as it will include node_modules folder. Please check https://www.unistyl.es/v3/other/babel-plugin#extra-configuration");
           }
-          state.file.replaceWithUnistyles = REPLACE_WITH_UNISTYLES_PATHS.map(toPlatformPath).concat(state.opts.autoProcessPaths ?? []).some((path3) => state.filename?.includes(path3));
+          state.file.replaceWithUnistyles = REPLACE_WITH_UNISTYLES_PATHS.concat(state.opts.autoProcessPaths ?? []).map(toPlatformPath).some((path3) => state.filename?.includes(path3));
           state.file.hasAnyUnistyle = false;
           state.file.hasUnistylesImport = false;
           state.file.addUnistylesRequire = false;

--- a/plugin/src/index.ts
+++ b/plugin/src/index.ts
@@ -34,8 +34,8 @@ export default function (): PluginObj<UnistylesPluginPass> {
                     }
 
                     state.file.replaceWithUnistyles = REPLACE_WITH_UNISTYLES_PATHS
-                        .map(toPlatformPath)
                         .concat(state.opts.autoProcessPaths ?? [])
+                        .map(toPlatformPath)
                         .some(path => state.filename?.includes(path))
 
                     state.file.hasAnyUnistyle = false


### PR DESCRIPTION
On Windows, setting the autoProcessPaths react-native-unstyles/plugin config does not work, meaning importing 3rd party component libraries that use react-native-unistyles are not transformed. This is a fix for that, using the already built-in `toPlatformPath` function to ensure windows paths are converted correctly (i.e use backslashes instead of forward slashes).

## Summary

While trying to install an npm package I made that uses Unistyles under the hood to style components, I noticed the components were not properly being transform when they implemented a StyleSheet. As you would expect, files in the `node_modules` were not by default being transformed - but the documentation specifies a workaround for this: https://www.unistyl.es/v3/other/babel-plugin#autoprocesspaths.

The problem was, I could not get it working. So I looked at the plugin code, and noticed that while I was defining my paths as `@somepackage/components`, the plugin's `state.filename` was in this format: `C:\someproject\node_modules\@somepackage\components`. The plugin already had a utility function (`toPlatformPath`) that converted the paths in the `REPLACE_WITH_UNISTYLES_PATHS` to support Windows paths, but this was not applied to the `autoProcessPaths` values.

This PR simply ensures both the `REPLACE_WITH_UNISTYLES_PATHS` and `autoProcessPaths` are converted to the correct format on Windows.

Just an aside, I really love Unistyles! Thank you for such a wonderful project.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the internal logic for determining file processing conditions, resulting in more consistent behavior when handling file paths. No changes to user-facing features or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->