### PR TITLE
feat: add dedicated breakpoint dependency handler to skip sealed check

### DIFF
--- a/cxx/core/Unistyle.h
+++ b/cxx/core/Unistyle.h
@@ -51,7 +51,7 @@ struct Unistyle {
         }
     }
 
-    inline void addBreakpointDependnecy() {
+    inline void addBreakpointDependency() {
         // this dependency can skip sealed check, as useVariants hook is called during React component render
         // also this is the only dependency that is not staticly deducted from Babel plugin
         auto it = std::find(this->dependencies.begin(), this->dependencies.end(), UnistyleDependency::BREAKPOINTS);

--- a/cxx/parser/Parser.cpp
+++ b/cxx/parser/Parser.cpp
@@ -694,7 +694,7 @@ jsi::Value parser::Parser::getValueFromBreakpoints(jsi::Runtime& rt, Unistyle::S
         auto mq = core::UnistylesMQ{propertyName};
 
         if (mq.isMQ()) {
-            unistyle->addBreakpointDependnecy();
+            unistyle->addBreakpointDependency();
         }
 
         if (mq.isWithinTheWidthAndHeight(dimensions)) {
@@ -707,7 +707,7 @@ jsi::Value parser::Parser::getValueFromBreakpoints(jsi::Runtime& rt, Unistyle::S
     bool hasOrientationBreakpoint = obj.hasProperty(rt, currentOrientation);
 
     if (hasOrientationBreakpoint) {
-        unistyle->addBreakpointDependnecy();
+        unistyle->addBreakpointDependency();
     }
 
     if (!hasBreakpoints && hasOrientationBreakpoint) {
@@ -718,7 +718,7 @@ jsi::Value parser::Parser::getValueFromBreakpoints(jsi::Runtime& rt, Unistyle::S
         return jsi::Value::undefined();
     }
 
-    unistyle->addBreakpointDependnecy();
+    unistyle->addBreakpointDependency();
 
     // if you're still here it means that there is no
     // matching mq nor default breakpoint, let's find the user defined breakpoint


### PR DESCRIPTION
## Summary

Fixes #921 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved how breakpoint dependencies are managed internally, resulting in more consistent handling of breakpoint-related features. There are no visible changes to the user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->