### PR TITLE
fix: getWebProps forwardedRef missing

### DIFF
--- a/src/web-only/getWebProps.ts
+++ b/src/web-only/getWebProps.ts
@@ -3,9 +3,9 @@ import { getClassName } from '../core'
 import type { RNStyle, UnistylesValues } from '../types'
 import { createUnistylesRef } from '../web/utils/createUnistylesRef'
 
-export const getWebProps = <T>(style: StyleProp<RNStyle>) => {
+export const getWebProps = <T>(style: StyleProp<RNStyle>, forwardedRef?: React.ForwardedRef<T>) => {
     const styles = getClassName(style as UnistylesValues)
-    const ref = createUnistylesRef<T>(styles)
+    const ref = createUnistylesRef<T>(styles, forwardedRef)
     const [generatedStyles] = styles ?? []
 
     return {


### PR DESCRIPTION
## Summary

When building [custom web components](https://www.unistyl.es/v3/guides/custom-web) without react native web [the docs](https://www.unistyl.es/v3/guides/custom-web) recommend using `getWebProps` to register the component for style updates.

However when using this function the ref is always created by `getWebProps` (via `createUnistylesRef`) and nothing above the custom component can access the ref.

The fix here takes the same approach as the other unistyle components that web uses with the babel plugin. For example `Image`.
https://github.com/jpudysz/react-native-unistyles/blob/b589b88d00e979340830e28b38124d8873d93d19/src/components/native/Image.tsx#L17


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved support for forwarding refs in web components, enabling enhanced integration with React ref patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->