### PR TITLE
fix: update Babel configuration to use path.resolve for the 'src' directory

### DIFF
--- a/docs/src/content/docs/v3/start/getting-started.mdx
+++ b/docs/src/content/docs/v3/start/getting-started.mdx
@@ -46,6 +46,7 @@ Check compatibility table [here](https://github.com/jpudysz/react-native-unistyl
 Add babel plugin:
 
 ```js title="babel.config.js"
+const path = require('path');
 module.exports = function (api) {
   api.cache(true)
 
@@ -64,7 +65,7 @@ module.exports = function (api) {
             // all files under this folder will be processed by the Babel plugin
             // if you need to include more folders, or customize discovery process
             // check available babel options
-            root: 'src'
+            root: path.resolve(__dirname, 'src')
         }]
     ]
   }


### PR DESCRIPTION
## Summary
When setting up Unistyles, the documentation currently shows:
`plugins: [
  ['react-native-unistyles/plugin', {
    root: 'src'
  }]
]`
This works fine in most cases, but when projects also use [babel-plugin-module-resolver](https://github.com/tleunen/babel-plugin-module-resolver) to handle absolute imports, using a plain string ('src') can cause Babel to misresolve paths.

To make configuration more robust and compatible with module resolvers, it’s better to use path.resolve:
`const path = require('path');
plugins: [
  ['react-native-unistyles/plugin', {
    root: path.resolve(__dirname, 'src')
  }]
]`
