### PR TITLE
feat: upgrade nitro-modules to 0.29.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,14 +21,14 @@ yarn add react-native-unistyles
 Install dependencies:
 
 ```shell
-yarn add react-native-edge-to-edge react-native-nitro-modules@0.28.0
+yarn add react-native-edge-to-edge react-native-nitro-modules@0.29.3
 ```
 
 > To avoid unexpected behavior, always use a fixed version of `react-native-nitro-modules`
 
 | react-native-unistyles | react-native-nitro-modules |
 |------------------------|----------------------------|
-| 3.0.0                  | 0.28.0                     |
+| 3.0.0                  | 0.29.3                     |
 
 Then follow [installation guides](https://unistyl.es/v3/start/getting-started) for your platform.
 

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -8,7 +8,7 @@ PODS:
   - hermes-engine (0.81.0):
     - hermes-engine/Pre-built (= 0.81.0)
   - hermes-engine/Pre-built (0.81.0)
-  - NitroModules (0.28.0):
+  - NitroModules (0.29.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -2431,7 +2431,7 @@ PODS:
     - SocketRocket
     - Yoga
   - SocketRocket (0.7.1)
-  - Unistyles (3.0.9):
+  - Unistyles (3.0.10):
     - boost
     - DoubleConversion
     - fast_float
@@ -2706,7 +2706,7 @@ SPEC CHECKSUMS:
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
   glog: 5683914934d5b6e4240e497e0f4a3b42d1854183
   hermes-engine: e7491a2038f2618c8cd444ed411a6deb350a3742
-  NitroModules: 54b9c7efd517b142c015a4a8dff49c779191627c
+  NitroModules: f6e563fa07d6bf28904dec2b46741da8a5f271b2
   RCT-Folly: 846fda9475e61ec7bcbf8a3fe81edfcaeb090669
   RCTDeprecation: 0735ab4f6b3ec93a7f98187b5da74d7916e2cf4c
   RCTRequired: 8fcc7801bfc433072287b0f24a662e2816e89d0c
@@ -2773,7 +2773,7 @@ SPEC CHECKSUMS:
   RNReanimated: ee96d03fe3713993a30cc205522792b4cb08e4f9
   RNWorklets: e8335dff9d27004709f58316985769040cd1e8f2
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
-  Unistyles: 19ca4b47ba5e9c38df58d630d6f32e7c51109390
+  Unistyles: 60d7dfe20e9b3131a6d171a689150d478a0445e1
   Yoga: 00013dd9cde63a2d98e8002fcc4f5ddb66c10782
 
 PODFILE CHECKSUM: a5de45e2350a9515567a6e18ca8ceea718b48523

--- a/example/package.json
+++ b/example/package.json
@@ -11,7 +11,7 @@
     "react": "19.1.0",
     "react-native": "0.81.0",
     "react-native-edge-to-edge": "1.6.1",
-    "react-native-nitro-modules": "0.28.0",
+    "react-native-nitro-modules": "0.29.3",
     "react-native-reanimated": "4.0.2",
     "react-native-unistyles": "workspace:*",
     "react-native-worklets": "0.4.1"

--- a/expo-example/package.json
+++ b/expo-example/package.json
@@ -22,7 +22,7 @@
     "react-native": "0.79.3",
     "react-native-edge-to-edge": "1.6.0",
     "react-native-gesture-handler": "2.25.0",
-    "react-native-nitro-modules": "0.28.0",
+    "react-native-nitro-modules": "0.29.3",
     "react-native-reanimated": "3.17.5",
     "react-native-safe-area-context": "5.4.0",
     "react-native-screens": "4.10.0",

--- a/nitrogen/generated/ios/Unistyles-Swift-Cxx-Bridge.cpp
+++ b/nitrogen/generated/ios/Unistyles-Swift-Cxx-Bridge.cpp
@@ -14,7 +14,7 @@
 namespace margelo::nitro::unistyles::bridge::swift {
 
   // pragma MARK: std::function<void(const std::vector<UnistyleDependency>& /* dependencies */, const UnistylesNativeMiniRuntime& /* miniRuntime */)>
-  Func_void_std__vector_UnistyleDependency__UnistylesNativeMiniRuntime create_Func_void_std__vector_UnistyleDependency__UnistylesNativeMiniRuntime(void* _Nonnull swiftClosureWrapper) {
+  Func_void_std__vector_UnistyleDependency__UnistylesNativeMiniRuntime create_Func_void_std__vector_UnistyleDependency__UnistylesNativeMiniRuntime(void* _Nonnull swiftClosureWrapper) noexcept {
     auto swiftClosure = Unistyles::Func_void_std__vector_UnistyleDependency__UnistylesNativeMiniRuntime::fromUnsafe(swiftClosureWrapper);
     return [swiftClosure = std::move(swiftClosure)](const std::vector<UnistyleDependency>& dependencies, const UnistylesNativeMiniRuntime& miniRuntime) mutable -> void {
       swiftClosure.call(dependencies, miniRuntime);
@@ -22,7 +22,7 @@ namespace margelo::nitro::unistyles::bridge::swift {
   }
   
   // pragma MARK: std::function<void(const UnistylesNativeMiniRuntime& /* miniRuntime */)>
-  Func_void_UnistylesNativeMiniRuntime create_Func_void_UnistylesNativeMiniRuntime(void* _Nonnull swiftClosureWrapper) {
+  Func_void_UnistylesNativeMiniRuntime create_Func_void_UnistylesNativeMiniRuntime(void* _Nonnull swiftClosureWrapper) noexcept {
     auto swiftClosure = Unistyles::Func_void_UnistylesNativeMiniRuntime::fromUnsafe(swiftClosureWrapper);
     return [swiftClosure = std::move(swiftClosure)](const UnistylesNativeMiniRuntime& miniRuntime) mutable -> void {
       swiftClosure.call(miniRuntime);
@@ -30,11 +30,11 @@ namespace margelo::nitro::unistyles::bridge::swift {
   }
   
   // pragma MARK: std::shared_ptr<HybridNativePlatformSpec>
-  std::shared_ptr<HybridNativePlatformSpec> create_std__shared_ptr_HybridNativePlatformSpec_(void* _Nonnull swiftUnsafePointer) {
+  std::shared_ptr<HybridNativePlatformSpec> create_std__shared_ptr_HybridNativePlatformSpec_(void* _Nonnull swiftUnsafePointer) noexcept {
     Unistyles::HybridNativePlatformSpec_cxx swiftPart = Unistyles::HybridNativePlatformSpec_cxx::fromUnsafe(swiftUnsafePointer);
     return std::make_shared<margelo::nitro::unistyles::HybridNativePlatformSpecSwift>(swiftPart);
   }
-  void* _Nonnull get_std__shared_ptr_HybridNativePlatformSpec_(std__shared_ptr_HybridNativePlatformSpec_ cppType) {
+  void* _Nonnull get_std__shared_ptr_HybridNativePlatformSpec_(std__shared_ptr_HybridNativePlatformSpec_ cppType) noexcept {
     std::shared_ptr<margelo::nitro::unistyles::HybridNativePlatformSpecSwift> swiftWrapper = std::dynamic_pointer_cast<margelo::nitro::unistyles::HybridNativePlatformSpecSwift>(cppType);
     #ifdef NITRO_DEBUG
     if (swiftWrapper == nullptr) [[unlikely]] {

--- a/nitrogen/generated/ios/Unistyles-Swift-Cxx-Bridge.hpp
+++ b/nitrogen/generated/ios/Unistyles-Swift-Cxx-Bridge.hpp
@@ -53,7 +53,7 @@ namespace margelo::nitro::unistyles::bridge::swift {
    * Specialized version of `std::vector<UnistyleDependency>`.
    */
   using std__vector_UnistyleDependency_ = std::vector<UnistyleDependency>;
-  inline std::vector<UnistyleDependency> create_std__vector_UnistyleDependency_(size_t size) {
+  inline std::vector<UnistyleDependency> create_std__vector_UnistyleDependency_(size_t size) noexcept {
     std::vector<UnistyleDependency> vector;
     vector.reserve(size);
     return vector;
@@ -70,14 +70,14 @@ namespace margelo::nitro::unistyles::bridge::swift {
   class Func_void_std__vector_UnistyleDependency__UnistylesNativeMiniRuntime_Wrapper final {
   public:
     explicit Func_void_std__vector_UnistyleDependency__UnistylesNativeMiniRuntime_Wrapper(std::function<void(const std::vector<UnistyleDependency>& /* dependencies */, const UnistylesNativeMiniRuntime& /* miniRuntime */)>&& func): _function(std::make_unique<std::function<void(const std::vector<UnistyleDependency>& /* dependencies */, const UnistylesNativeMiniRuntime& /* miniRuntime */)>>(std::move(func))) {}
-    inline void call(std::vector<UnistyleDependency> dependencies, UnistylesNativeMiniRuntime miniRuntime) const {
+    inline void call(std::vector<UnistyleDependency> dependencies, UnistylesNativeMiniRuntime miniRuntime) const noexcept {
       _function->operator()(dependencies, miniRuntime);
     }
   private:
     std::unique_ptr<std::function<void(const std::vector<UnistyleDependency>& /* dependencies */, const UnistylesNativeMiniRuntime& /* miniRuntime */)>> _function;
   } SWIFT_NONCOPYABLE;
-  Func_void_std__vector_UnistyleDependency__UnistylesNativeMiniRuntime create_Func_void_std__vector_UnistyleDependency__UnistylesNativeMiniRuntime(void* _Nonnull swiftClosureWrapper);
-  inline Func_void_std__vector_UnistyleDependency__UnistylesNativeMiniRuntime_Wrapper wrap_Func_void_std__vector_UnistyleDependency__UnistylesNativeMiniRuntime(Func_void_std__vector_UnistyleDependency__UnistylesNativeMiniRuntime value) {
+  Func_void_std__vector_UnistyleDependency__UnistylesNativeMiniRuntime create_Func_void_std__vector_UnistyleDependency__UnistylesNativeMiniRuntime(void* _Nonnull swiftClosureWrapper) noexcept;
+  inline Func_void_std__vector_UnistyleDependency__UnistylesNativeMiniRuntime_Wrapper wrap_Func_void_std__vector_UnistyleDependency__UnistylesNativeMiniRuntime(Func_void_std__vector_UnistyleDependency__UnistylesNativeMiniRuntime value) noexcept {
     return Func_void_std__vector_UnistyleDependency__UnistylesNativeMiniRuntime_Wrapper(std::move(value));
   }
   
@@ -92,14 +92,14 @@ namespace margelo::nitro::unistyles::bridge::swift {
   class Func_void_UnistylesNativeMiniRuntime_Wrapper final {
   public:
     explicit Func_void_UnistylesNativeMiniRuntime_Wrapper(std::function<void(const UnistylesNativeMiniRuntime& /* miniRuntime */)>&& func): _function(std::make_unique<std::function<void(const UnistylesNativeMiniRuntime& /* miniRuntime */)>>(std::move(func))) {}
-    inline void call(UnistylesNativeMiniRuntime miniRuntime) const {
+    inline void call(UnistylesNativeMiniRuntime miniRuntime) const noexcept {
       _function->operator()(miniRuntime);
     }
   private:
     std::unique_ptr<std::function<void(const UnistylesNativeMiniRuntime& /* miniRuntime */)>> _function;
   } SWIFT_NONCOPYABLE;
-  Func_void_UnistylesNativeMiniRuntime create_Func_void_UnistylesNativeMiniRuntime(void* _Nonnull swiftClosureWrapper);
-  inline Func_void_UnistylesNativeMiniRuntime_Wrapper wrap_Func_void_UnistylesNativeMiniRuntime(Func_void_UnistylesNativeMiniRuntime value) {
+  Func_void_UnistylesNativeMiniRuntime create_Func_void_UnistylesNativeMiniRuntime(void* _Nonnull swiftClosureWrapper) noexcept;
+  inline Func_void_UnistylesNativeMiniRuntime_Wrapper wrap_Func_void_UnistylesNativeMiniRuntime(Func_void_UnistylesNativeMiniRuntime value) noexcept {
     return Func_void_UnistylesNativeMiniRuntime_Wrapper(std::move(value));
   }
   
@@ -108,91 +108,91 @@ namespace margelo::nitro::unistyles::bridge::swift {
    * Specialized version of `std::shared_ptr<HybridNativePlatformSpec>`.
    */
   using std__shared_ptr_HybridNativePlatformSpec_ = std::shared_ptr<HybridNativePlatformSpec>;
-  std::shared_ptr<HybridNativePlatformSpec> create_std__shared_ptr_HybridNativePlatformSpec_(void* _Nonnull swiftUnsafePointer);
-  void* _Nonnull get_std__shared_ptr_HybridNativePlatformSpec_(std__shared_ptr_HybridNativePlatformSpec_ cppType);
+  std::shared_ptr<HybridNativePlatformSpec> create_std__shared_ptr_HybridNativePlatformSpec_(void* _Nonnull swiftUnsafePointer) noexcept;
+  void* _Nonnull get_std__shared_ptr_HybridNativePlatformSpec_(std__shared_ptr_HybridNativePlatformSpec_ cppType) noexcept;
   
   // pragma MARK: std::weak_ptr<HybridNativePlatformSpec>
   using std__weak_ptr_HybridNativePlatformSpec_ = std::weak_ptr<HybridNativePlatformSpec>;
-  inline std__weak_ptr_HybridNativePlatformSpec_ weakify_std__shared_ptr_HybridNativePlatformSpec_(const std::shared_ptr<HybridNativePlatformSpec>& strong) { return strong; }
+  inline std__weak_ptr_HybridNativePlatformSpec_ weakify_std__shared_ptr_HybridNativePlatformSpec_(const std::shared_ptr<HybridNativePlatformSpec>& strong) noexcept { return strong; }
   
   // pragma MARK: Result<Insets>
   using Result_Insets_ = Result<Insets>;
-  inline Result_Insets_ create_Result_Insets_(const Insets& value) {
+  inline Result_Insets_ create_Result_Insets_(const Insets& value) noexcept {
     return Result<Insets>::withValue(value);
   }
-  inline Result_Insets_ create_Result_Insets_(const std::exception_ptr& error) {
+  inline Result_Insets_ create_Result_Insets_(const std::exception_ptr& error) noexcept {
     return Result<Insets>::withError(error);
   }
   
   // pragma MARK: Result<ColorScheme>
   using Result_ColorScheme_ = Result<ColorScheme>;
-  inline Result_ColorScheme_ create_Result_ColorScheme_(ColorScheme value) {
+  inline Result_ColorScheme_ create_Result_ColorScheme_(ColorScheme value) noexcept {
     return Result<ColorScheme>::withValue(std::move(value));
   }
-  inline Result_ColorScheme_ create_Result_ColorScheme_(const std::exception_ptr& error) {
+  inline Result_ColorScheme_ create_Result_ColorScheme_(const std::exception_ptr& error) noexcept {
     return Result<ColorScheme>::withError(error);
   }
   
   // pragma MARK: Result<double>
   using Result_double_ = Result<double>;
-  inline Result_double_ create_Result_double_(double value) {
+  inline Result_double_ create_Result_double_(double value) noexcept {
     return Result<double>::withValue(std::move(value));
   }
-  inline Result_double_ create_Result_double_(const std::exception_ptr& error) {
+  inline Result_double_ create_Result_double_(const std::exception_ptr& error) noexcept {
     return Result<double>::withError(error);
   }
   
   // pragma MARK: Result<Orientation>
   using Result_Orientation_ = Result<Orientation>;
-  inline Result_Orientation_ create_Result_Orientation_(Orientation value) {
+  inline Result_Orientation_ create_Result_Orientation_(Orientation value) noexcept {
     return Result<Orientation>::withValue(std::move(value));
   }
-  inline Result_Orientation_ create_Result_Orientation_(const std::exception_ptr& error) {
+  inline Result_Orientation_ create_Result_Orientation_(const std::exception_ptr& error) noexcept {
     return Result<Orientation>::withError(error);
   }
   
   // pragma MARK: Result<std::string>
   using Result_std__string_ = Result<std::string>;
-  inline Result_std__string_ create_Result_std__string_(const std::string& value) {
+  inline Result_std__string_ create_Result_std__string_(const std::string& value) noexcept {
     return Result<std::string>::withValue(value);
   }
-  inline Result_std__string_ create_Result_std__string_(const std::exception_ptr& error) {
+  inline Result_std__string_ create_Result_std__string_(const std::exception_ptr& error) noexcept {
     return Result<std::string>::withError(error);
   }
   
   // pragma MARK: Result<Dimensions>
   using Result_Dimensions_ = Result<Dimensions>;
-  inline Result_Dimensions_ create_Result_Dimensions_(const Dimensions& value) {
+  inline Result_Dimensions_ create_Result_Dimensions_(const Dimensions& value) noexcept {
     return Result<Dimensions>::withValue(value);
   }
-  inline Result_Dimensions_ create_Result_Dimensions_(const std::exception_ptr& error) {
+  inline Result_Dimensions_ create_Result_Dimensions_(const std::exception_ptr& error) noexcept {
     return Result<Dimensions>::withError(error);
   }
   
   // pragma MARK: Result<bool>
   using Result_bool_ = Result<bool>;
-  inline Result_bool_ create_Result_bool_(bool value) {
+  inline Result_bool_ create_Result_bool_(bool value) noexcept {
     return Result<bool>::withValue(std::move(value));
   }
-  inline Result_bool_ create_Result_bool_(const std::exception_ptr& error) {
+  inline Result_bool_ create_Result_bool_(const std::exception_ptr& error) noexcept {
     return Result<bool>::withError(error);
   }
   
   // pragma MARK: Result<void>
   using Result_void_ = Result<void>;
-  inline Result_void_ create_Result_void_() {
+  inline Result_void_ create_Result_void_() noexcept {
     return Result<void>::withValue();
   }
-  inline Result_void_ create_Result_void_(const std::exception_ptr& error) {
+  inline Result_void_ create_Result_void_(const std::exception_ptr& error) noexcept {
     return Result<void>::withError(error);
   }
   
   // pragma MARK: Result<UnistylesNativeMiniRuntime>
   using Result_UnistylesNativeMiniRuntime_ = Result<UnistylesNativeMiniRuntime>;
-  inline Result_UnistylesNativeMiniRuntime_ create_Result_UnistylesNativeMiniRuntime_(const UnistylesNativeMiniRuntime& value) {
+  inline Result_UnistylesNativeMiniRuntime_ create_Result_UnistylesNativeMiniRuntime_(const UnistylesNativeMiniRuntime& value) noexcept {
     return Result<UnistylesNativeMiniRuntime>::withValue(value);
   }
-  inline Result_UnistylesNativeMiniRuntime_ create_Result_UnistylesNativeMiniRuntime_(const std::exception_ptr& error) {
+  inline Result_UnistylesNativeMiniRuntime_ create_Result_UnistylesNativeMiniRuntime_(const std::exception_ptr& error) noexcept {
     return Result<UnistylesNativeMiniRuntime>::withError(error);
   }
 

--- a/package.json
+++ b/package.json
@@ -179,7 +179,7 @@
   ],
   "packageManager": "yarn@3.6.1",
   "engines": {
-    "node": ">= 20.0.0"
+    "node": ">= 18.0.0"
   },
   "jest": {
     "preset": "react-native",

--- a/package.json
+++ b/package.json
@@ -148,11 +148,11 @@
     "husky": "9.1.7",
     "jest": "29.7.0",
     "metro-react-native-babel-preset": "0.77.0",
-    "nitro-codegen": "0.28.0",
+    "nitro-codegen": "0.29.3",
     "react": "19.1.0",
     "react-native": "0.79.2",
     "react-native-builder-bob": "0.40.10",
-    "react-native-nitro-modules": "0.28.0",
+    "react-native-nitro-modules": "0.29.3",
     "react-native-reanimated": "3.17.5",
     "react-native-web": "0.20.0",
     "react-test-renderer": "19.1.0",
@@ -179,7 +179,7 @@
   ],
   "packageManager": "yarn@3.6.1",
   "engines": {
-    "node": ">= 18.0.0"
+    "node": ">= 20.0.0"
   },
   "jest": {
     "preset": "react-native",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10211,7 +10211,7 @@ __metadata:
     react: 19.1.0
     react-native: 0.81.0
     react-native-edge-to-edge: 1.6.1
-    react-native-nitro-modules: 0.28.0
+    react-native-nitro-modules: 0.29.3
     react-native-reanimated: 4.0.2
     react-native-unistyles: "workspace:*"
     react-native-worklets: 0.4.1
@@ -10390,7 +10390,7 @@ __metadata:
     react-native: 0.79.3
     react-native-edge-to-edge: 1.6.0
     react-native-gesture-handler: 2.25.0
-    react-native-nitro-modules: 0.28.0
+    react-native-nitro-modules: 0.29.3
     react-native-reanimated: 3.17.5
     react-native-safe-area-context: 5.4.0
     react-native-screens: 4.10.0
@@ -16421,18 +16421,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nitro-codegen@npm:0.28.0":
-  version: 0.28.0
-  resolution: "nitro-codegen@npm:0.28.0"
+"nitro-codegen@npm:0.29.3":
+  version: 0.29.3
+  resolution: "nitro-codegen@npm:0.29.3"
   dependencies:
     chalk: ^5.3.0
-    react-native-nitro-modules: ^0.28.0
+    react-native-nitro-modules: ^0.29.3
     ts-morph: ^25.0.0
     yargs: ^17.7.2
     zod: ^4.0.5
   bin:
     nitro-codegen: lib/index.js
-  checksum: 8f7395e830f246c9348d7b6a152a11374aef8e28ca24b0df26d8acde8fe10bd8fdc6836a8b599838bb7723ebe4c9b00903e44acbfd5102ec3a939aa6aa9df287
+  checksum: 2c9577c6eae3e5fa2627967b2d31eb1b6362abfd9a9e3f8a4ff31194034fa933119ff12c27d40c227e169f9dad53664ecf842ed5287aecb3edbfd089434aabe1
   languageName: node
   linkType: hard
 
@@ -18092,13 +18092,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-nitro-modules@npm:0.28.0, react-native-nitro-modules@npm:^0.28.0":
-  version: 0.28.0
-  resolution: "react-native-nitro-modules@npm:0.28.0"
+"react-native-nitro-modules@npm:0.29.3, react-native-nitro-modules@npm:^0.29.3":
+  version: 0.29.3
+  resolution: "react-native-nitro-modules@npm:0.29.3"
   peerDependencies:
     react: "*"
     react-native: "*"
-  checksum: 9cfca20c0257b4f7632407b40196e3ac88578d1a7f727093e1b08508a9dd640ed80f7be0de208f8c59e5553e58f8383772e6996c5941935c26433bb3539c75be
+  checksum: 8bfa0cb2de6fb9a9ddbb0696a16c2f03d0540af9e3466d542890b802fbdd0e1082de722b38381966a7fd1193cfdd93ffd8308caa7a0157f1df5169a301155163
   languageName: node
   linkType: hard
 
@@ -18209,11 +18209,11 @@ __metadata:
     husky: 9.1.7
     jest: 29.7.0
     metro-react-native-babel-preset: 0.77.0
-    nitro-codegen: 0.28.0
+    nitro-codegen: 0.29.3
     react: 19.1.0
     react-native: 0.79.2
     react-native-builder-bob: 0.40.10
-    react-native-nitro-modules: 0.28.0
+    react-native-nitro-modules: 0.29.3
     react-native-reanimated: 3.17.5
     react-native-web: 0.20.0
     react-test-renderer: 19.1.0


### PR DESCRIPTION
## Summary

<!-- Explain the motivation for this PR. Include "Fixes #<number>" if applicable. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Documentation
  - Updated installation instructions and compatibility table to reference react-native-nitro-modules 0.29.3.

- Chores
  - Upgraded react-native-nitro-modules to 0.29.3 across packages (root, example, expo-example).
  - Upgraded nitro-codegen to 0.29.3.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->