### PR TITLE
chore: add shared value mocks for get/set

### DIFF
--- a/src/mocks.ts
+++ b/src/mocks.ts
@@ -220,6 +220,8 @@ jest.mock('react-native-unistyles', () => {
 jest.mock('react-native-unistyles/reanimated', () => {
     const unistyles = require('react-native-unistyles')
     const mockedSharedValue = (value: any) => ({
+        get: () => value,
+        set: (value: any) => {},
         value
     })
 

--- a/src/mocks.ts
+++ b/src/mocks.ts
@@ -221,7 +221,7 @@ jest.mock('react-native-unistyles/reanimated', () => {
     const unistyles = require('react-native-unistyles')
     const mockedSharedValue = (value: any) => ({
         get: () => value,
-        set: (value: any) => {},
+        set: (_value: any) => {},
         value
     })
 


### PR DESCRIPTION
## Summary

When using the React Compiler, [Reanimated recommends using `get`/`set` for shared values](https://docs.swmansion.com/react-native-reanimated/docs/core/useSharedValue/#react-compiler-support). This PR adds those functions to the mocks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test mocks for animated/shared values by adding get and set accessors, enabling clearer assertions and simulated state changes in tests. This increases test flexibility and reduces flakiness without affecting production behavior or user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->