### PR TITLE
fix: add validation checks for objects simiallar to StyleSheet when babel is forcing transformation

### DIFF
--- a/plugin/__tests__/playground.js
+++ b/plugin/__tests__/playground.js
@@ -5,7 +5,12 @@ const filePath = '../../expo-example/app/(tabs)/index.tsx'
 
 const result = babel.transformFileSync(filePath, {
     presets: ['@babel/preset-typescript', '@babel/preset-flow'],
-    plugins: [plugin],
+    plugins: [[
+        plugin,
+        {
+            root: '../../expo-example'
+        }
+    ]],
     filename: filePath
 })
 

--- a/plugin/index.js
+++ b/plugin/index.js
@@ -352,6 +352,15 @@ function isKindOfStyleSheet(path2, state) {
   if (!state.file.forceProcessing && !state.file.hasUnistylesImport) {
     return false;
   }
+  if (path2.node.arguments.length !== 1) {
+    return false;
+  }
+  if (!t4.isObjectExpression(path2.node.arguments[0])) {
+    return false;
+  }
+  if (!path2.node.arguments[0].properties.some((property) => t4.isObjectProperty(property) && t4.isObjectExpression(property.value))) {
+    return false;
+  }
   const { callee } = path2.node;
   return t4.isMemberExpression(callee) && t4.isIdentifier(callee.property) && callee.property.name === "create" && t4.isIdentifier(callee.object);
 }

--- a/plugin/src/stylesheet.ts
+++ b/plugin/src/stylesheet.ts
@@ -230,6 +230,18 @@ export function isKindOfStyleSheet(path: NodePath<t.CallExpression>, state: Unis
         return false
     }
 
+    if (path.node.arguments.length !== 1) {
+        return false
+    }
+
+    if (!t.isObjectExpression(path.node.arguments[0])) {
+        return false
+    }
+
+    if (!path.node.arguments[0].properties.some(property => t.isObjectProperty(property) && t.isObjectExpression(property.value))) {
+        return false
+    }
+
     const { callee } = path.node
 
     return (


### PR DESCRIPTION
## Summary

Fixes #993 
