### PR TITLE
fix: cxx distinguish between null and undefined values to allow for default function arguments

### DIFF
--- a/cxx/common/UnistylesConstants.h
+++ b/cxx/common/UnistylesConstants.h
@@ -11,5 +11,6 @@ static const std::string WEB_STYLE_KEY = "_web";
 static const std::string EXOTIC_STYLE_KEY = "_exotic";
 static const std::string ARGUMENTS = "__uni__args";
 static const std::string GET_STYLES = "uni__getStyles";
+static const std::string UNDEFINED_MARKER = "__unistyles_undefined__";
 
 }

--- a/cxx/parser/Parser.cpp
+++ b/cxx/parser/Parser.cpp
@@ -98,7 +98,7 @@ void parser::Parser::rebuildUnistyleWithScopedTheme(jsi::Runtime& rt, jsi::Value
     for (int i = 0; i < arguments.size(); i++) {
         folly::dynamic& arg = arguments.at(i);
 
-        args.emplace_back(jsi::valueFromDynamic(rt, arg));
+        args.emplace_back(helpers::dynamicToJSIValue(rt, arg));
     }
 
     const jsi::Value *argStart = args.data();
@@ -193,7 +193,7 @@ void parser::Parser::rebuildUnistyleWithVariants(jsi::Runtime& rt, std::shared_p
     for (int i = 0; i < arguments.size(); i++) {
         folly::dynamic& arg = arguments.at(i);
 
-        args.emplace_back(jsi::valueFromDynamic(rt, arg));
+        args.emplace_back(helpers::dynamicToJSIValue(rt, arg));
     }
 
     const jsi::Value *argStart = args.data();
@@ -350,7 +350,7 @@ void parser::Parser::rebuildUnistyle(jsi::Runtime& rt, Unistyle::Shared unistyle
         for (int i = 0; i < dynamicFunctionMetadata.size(); i++) {
             folly::dynamic& arg = dynamicFunctionMetadata.at(i);
 
-            args.emplace_back(jsi::valueFromDynamic(rt, arg));
+            args.emplace_back(helpers::dynamicToJSIValue(rt, arg));
         }
 
         const jsi::Value *argStart = args.data();


### PR DESCRIPTION
## Summary

 Before:
  - undefined → folly::dynamic() → null → Function called with null → Default parameter ignored
  
  After:
  - undefined → folly::dynamic() → undefined → Function called with undefined → Default parameter taken

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Undefined arguments are now correctly treated as “undefined,” ensuring consistent behavior in style-related function calls and preventing unexpected defaults or rendering anomalies.
* **Refactor**
  * Unified argument conversion to improve reliability when bridging values between native and JavaScript.
  * Minor formatting cleanups with no functional impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->