### PR TITLE
fix: useVariants C++ memory leak

### DIFF
--- a/cxx/core/HostUnistyle.cpp
+++ b/cxx/core/HostUnistyle.cpp
@@ -18,7 +18,9 @@ std::vector<jsi::PropNameID> HostUnistyle::getPropertyNames(jsi::Runtime& rt) {
 }
 
 HostUnistyle::~HostUnistyle() {
-    this->_stylesheet->unistyles.clear();
+    if (this->_ownsStyleSheet) {
+        this->_stylesheet->unistyles.clear();
+    }
 }
 
 jsi::Value HostUnistyle::get(jsi::Runtime& rt, const jsi::PropNameID& propNameId) {
@@ -96,23 +98,23 @@ jsi::Function HostUnistyle::createAddVariantsProxyFunction(jsi::Runtime& rt) {
             this->_stylesheet->type,
             jsi::Value(rt, this->_stylesheet->rawValue).asObject(rt)
         );
-        
+
         parser.buildUnistyles(rt, stylesheetCopy);
         parser.parseUnistyles(rt, stylesheetCopy);
-        
+
         helpers::enumerateJSIObject(rt, thisVal.asObject(rt), [this, &parser, &rt, &variants, stylesheetCopy](const std::string& name, jsi::Value& value){
             if (name == helpers::ADD_VARIANTS_FN || !stylesheetCopy->unistyles.contains(name)) {
                 return;
             }
 
             auto unistyle = stylesheetCopy->unistyles[name];
-            
+
             if (unistyle->dependsOn(UnistyleDependency::VARIANTS)) {
                 parser.rebuildUnistyle(rt, unistyle, variants, std::nullopt);
             }
         });
 
-        auto style = std::make_shared<core::HostUnistyle>(stylesheetCopy, this->_unistylesRuntime, variants);
+        auto style = std::make_shared<core::HostUnistyle>(stylesheetCopy, this->_unistylesRuntime, variants, true);
         auto styleHostObject = jsi::Object::createFromHostObject(rt, style);
 
         return styleHostObject;

--- a/cxx/core/HostUnistyle.h
+++ b/cxx/core/HostUnistyle.h
@@ -9,8 +9,8 @@ namespace margelo::nitro::unistyles::core {
 using Variants = std::vector<std::pair<std::string, std::string>>;
 
 struct JSI_EXPORT HostUnistyle : public jsi::HostObject {
-    HostUnistyle(std::shared_ptr<StyleSheet> stylesheet, std::shared_ptr<HybridUnistylesRuntime> unistylesRuntime, Variants& variants)
-        : _stylesheet(stylesheet), _unistylesRuntime{unistylesRuntime}, _variants{std::move(variants)} {};
+    HostUnistyle(std::shared_ptr<StyleSheet> stylesheet, std::shared_ptr<HybridUnistylesRuntime> unistylesRuntime, Variants& variants, bool ownsStyleSheet = false)
+        : _stylesheet(stylesheet), _unistylesRuntime{unistylesRuntime}, _variants{std::move(variants)}, _ownsStyleSheet(ownsStyleSheet) {};
     ~HostUnistyle();
 
     std::vector<jsi::PropNameID> getPropertyNames(jsi::Runtime& rt);
@@ -20,6 +20,7 @@ struct JSI_EXPORT HostUnistyle : public jsi::HostObject {
     jsi::Function createAddVariantsProxyFunction(jsi::Runtime& rt);
 
 private:
+    bool _ownsStyleSheet;
     Variants _variants;
     std::shared_ptr<StyleSheet> _stylesheet;
     std::shared_ptr<HybridUnistylesRuntime> _unistylesRuntime;


### PR DESCRIPTION
## Summary

Fixes #1034 

Before:
<img width="1269" height="721" alt="SCR-20251119-rlyk" src="https://github.com/user-attachments/assets/42d4987d-79b8-4090-afc0-5b451e5ca337" />


After:

<img width="1272" height="595" alt="SCR-20251119-rlzu" src="https://github.com/user-attachments/assets/9459353f-76cc-4d30-8aea-4a70ecc9fee3" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved lifecycle handling to ensure stylesheet-related resources are cleaned up when appropriate, reducing risk of stale styles and memory retention.
* **Bug Fixes**
  * Prevents leftover/unapplied style data after temporary style owners are destroyed, improving stability of style updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->