### PR TITLE
fix(docs): fix variable name in v3 reanimated guide docs

### DIFF
--- a/docs/src/content/docs/v3/guides/reanimated.mdx
+++ b/docs/src/content/docs/v3/guides/reanimated.mdx
@@ -118,7 +118,7 @@ export const MyAnimatedComponent = () => {
     )
 }
 
-const style = StyleSheet.create(theme => ({
+const styles = StyleSheet.create(theme => ({
     container: {
         flex: 1,
         justifyContent: 'center',
@@ -146,7 +146,7 @@ export const MyAnimatedComponent = () => {
     )
 }
 
-const style = StyleSheet.create(theme => ({
+const styles = StyleSheet.create(theme => ({
     container: {
         flex: 1,
         justifyContent: 'center',


### PR DESCRIPTION
## Summary

I was reading the documentation and realized that two variable names are incorrect in this page:
https://www.unistyl.es/v3/guides/reanimated

Changing the name of the variable to `styles` instead of changing where it is referenced to avoid multiple `style`s in the same scope.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated code examples in the Reanimated guide with consistent variable naming.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->