### PR TITLE
fix: hot reload for shouldUsePointsForBreakpoints while switching between points and pixels

### DIFF
--- a/cxx/hybridObjects/HybridStyleSheet.cpp
+++ b/cxx/hybridObjects/HybridStyleSheet.cpp
@@ -100,6 +100,9 @@ jsi::Value HybridStyleSheet::init(jsi::Runtime &rt, const jsi::Value &thisVal, c
 void HybridStyleSheet::parseSettings(jsi::Runtime &rt, jsi::Object settings) {
     auto& registry = core::UnistylesRegistry::get();
 
+    // set defafults
+    registry.shouldUsePointsForBreakpoints = false;
+
     helpers::enumerateJSIObject(rt, settings, [&](const std::string& propertyName, jsi::Value& propertyValue){
         if (propertyName == "adaptiveThemes") {
             helpers::assertThat(rt, propertyValue.isBool(), "StyleSheet.configure's adaptiveThemes must be of boolean type.");


### PR DESCRIPTION
## Summary

Improves #1049


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted default breakpoint unit configuration to ensure consistent styling calculations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->