### PR TITLE
fix(android): use DISPATCH_MODE_CONTINUE_ON_SUBTREE for keyboard insets

### DIFF
--- a/android/src/main/java/com/unistyles/NativePlatform+insets.kt
+++ b/android/src/main/java/com/unistyles/NativePlatform+insets.kt
@@ -139,7 +139,7 @@ class NativePlatformInsets(
                 if (Build.VERSION.SDK_INT >= 30) {
                     ViewCompat.setWindowInsetsAnimationCallback(
                         mainView,
-                        object : WindowInsetsAnimationCompat.Callback(DISPATCH_MODE_STOP) {
+                        object : WindowInsetsAnimationCompat.Callback(DISPATCH_MODE_CONTINUE_ON_SUBTREE) {
                             override fun onProgress(
                                 insets: WindowInsetsCompat,
                                 runningAnimations: List<WindowInsetsAnimationCompat>


### PR DESCRIPTION
## Summary

<!-- Explain the motivation for this PR. Include "Fixes #<number>" if applicable. -->

Fixes #1060

### Problem

On Android 11+ (API 30+), using Unistyles alongside other libraries that observe keyboard animations (e.g., `react-native-true-sheet`, `react-native-reanimated`, `react-native-screens`) causes those libraries' keyboard observers to stop working.

### Cause

The `WindowInsetsAnimationCallback` in `NativePlatform+insets.kt` was using `DISPATCH_MODE_STOP`, which prevents keyboard animation events from propagating to child views in the hierarchy. Since Unistyles sets this callback on `android.R.id.content` (the root content view), no child views receive `onPrepare`, `onStart`, `onProgress`, or `onEnd` callbacks.

### Solution

Changed `DISPATCH_MODE_STOP` to `DISPATCH_MODE_CONTINUE_ON_SUBTREE`, allowing child views to also receive keyboard animation callbacks.

### Impact

- No functional change to Unistyles - keyboard inset tracking works identically
- Enables compatibility with other libraries that rely on `WindowInsetsAnimationCallback

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard and UI animation behavior on Android 30 and higher, ensuring smoother propagation of inset animations across the interface.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->