### PR TITLE
Container query provider

### DIFF
--- a/src/components/UnistylesBreakpointContainerProvider.tsx
+++ b/src/components/UnistylesBreakpointContainerProvider.tsx
@@ -62,6 +62,7 @@ export const UnistylesBreakpointContainerProvider: React.FunctionComponent<Conta
     const containerStyle: React.CSSProperties = {
         display: 'flex',
         flexDirection: 'column',
+        containerType: 'inline-size',
         containerName,
         ...(style as React.CSSProperties)
     }


### PR DESCRIPTION
## Summary

<!-- Explain the motivation for this PR. Include "Fixes #<number>" if applicable. -->

I'm opening this up as a draft to make it easier to discuss the changes and solicit feedback. I've been using this in one of my apps and it's been working really well on both web and native.

There's some related discussion here: https://github.com/jpudysz/react-native-unistyles/discussions/853

I've separated the work into 2 main commits to make a feedback review easier to digest: the first commit on the branch updates the shadow tree style computation and adds a new provider export, the second commit updates the useUnistyles hook to expose a container breakpoint.

# Problem

Today, Unistyles breakpoints are computed from the application window size. That works well for most cases, but it breaks down when a component is rendered inside a resizable container and needs to style itself based on the container width instead of the window width. A concrete example is a custom SplitView layout on larger screens, where two panes are shown side by side. Each pane may need to render different UI based on the pane width, not the full app window width.

This comes up in the existing container queries discussion as well, including the split view / navigator use case and the desire to avoid passing container size through dynamic style functions because that causes extra re-renders.  ￼

# Proposal

Unistyles already has a `ScopedTheme` that ergonomically works very similarly to what we need here. So I've added an opt-in `UnistylesBreakpointContainerProvider` (yes, it's a mouthful, I need to pick a shorter name) that marks a view as the breakpoint source for its subtree.

Inside that subtree:
* breakpoint resolution uses the provider container size instead of the application window size*
*	the nearest provider wins when providers are nested
*	updates remain render-free for native views by pushing container size changes into the existing shadow-tree-based style recomputation path

There are three main pieces to support this:
1.	Shadow tree linking / style recomputation
	* Track which nodes belong to which container breakpoint scope.
	*	Recompute affected styles when the provider container size changes.
2.	useUnistyles runtime access
	*	Expose the active breakpoint for the current container scope somewhere in useUnistyles, so components that rely on the hook can observe the same scoped breakpoint source.
	*	The current implementation here was hacked in on the react side and I'm sure there's a better way to do this on the c++ side. I'm currently exposing a `containerBreakpoint` in the return from `useUnistyles` but I suspect updating how `rt.breakpoint` is computed is probably the better approach? That way a caller that needs a breakpoint on the react side can simply subscribe to `useUnistyles`, consume `rt.breakpoint`, and it will always work whether it's in a container or not.
3. Use container queries instead of media queries when compiling the css

I've separated the shadow tree and useUnistyles work into separate commits so they can be reviewed individually.


