### PR TITLE
feat: clean up git history and add missing gitignore entries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,14 @@ packages/unistyles/cxx/tests/cmake-build-debug-coverage/
 
 packages/unistyles/src/**/*.js
 tsconfig.tsbuildinfo
+
+# Yarn PnP cache
+.yarn/cache/
+.yarn/releases/
+.yarn/plugins/
+
+# CocoaPods
+**/ios/Pods/
+
+# Next.js
+.next/

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "devDependencies": {
     "husky": "9.1.7"
   },
+  "packageManager": "bun@1.3.2",
   "engines": {
     "node": ">= 20.0.0"
   }


### PR DESCRIPTION
## Summary
- Remove `.yarn/cache/`, `ios/Pods/` and `.next/` from git history, reducing repo size from 322 MiB to 20 MiB
- Add missing `.gitignore` entries for `.yarn/cache`, `**/ios/Pods/`, and `.next/`
- Add `packageManager: bun@1.3.2` field to root `package.json`

## Test plan
- [x] All pre-commit checks pass (tsc, lint, check, test, circular)
- [x] Verify repo clone size is reduced

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project configuration to standardize the package manager used during development.
  * Expanded ignore patterns to properly exclude build outputs, dependency directories, and cache files from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->