### PR TITLE
fix(web): make style properties enumerable for third-party component compatibility

### DIFF
--- a/packages/unistyles/src/web/utils/unistyle.ts
+++ b/packages/unistyles/src/web/utils/unistyle.ts
@@ -58,14 +58,16 @@ export const extractSecrets = (object: any) => {
     return reduceObject(Object.getOwnPropertyDescriptors(secrets), (secret) => secret.value)
 }
 
+const UNISTYLES_METADATA_KEYS = new Set(['variants', 'compoundVariants', '_web', 'uni__dependencies', '_classNames'])
+
 export const removeInlineStyles = (values: UnistylesValues) => {
     const returnValue = {}
 
     Object.defineProperties(
         returnValue,
-        reduceObject(values, (value) => ({
+        reduceObject(values, (value, key) => ({
             value,
-            enumerable: true,
+            enumerable: !UNISTYLES_METADATA_KEYS.has(key as string),
             configurable: true,
         })),
     )

--- a/packages/unistyles/src/web/utils/unistyle.ts
+++ b/packages/unistyles/src/web/utils/unistyle.ts
@@ -65,7 +65,7 @@ export const removeInlineStyles = (values: UnistylesValues) => {
         returnValue,
         reduceObject(values, (value) => ({
             value,
-            enumerable: false,
+            enumerable: true,
             configurable: true,
         })),
     )


### PR DESCRIPTION
## Summary

Fixes #1165

One-line fix: `enumerable: false` → `enumerable: true` in `removeInlineStyles()`.

This fixes **invisible images** (and potentially other rendering issues) when using third-party components like `expo-image` on web.

## The problem

`removeInlineStyles()` in `src/web/utils/unistyle.ts` creates style objects with **non-enumerable** CSS properties. All standard JS APIs skip non-enumerable properties:

```js
const styles = StyleSheet.create({ image: { width: '100%', height: 300 } });

Object.keys(styles.image)        // → []     (empty!)
Object.assign({}, styles.image)  // → {}     (empty!)
{ ...styles.image }              // → {}     (empty!)
StyleSheet.flatten(styles.image) // → {}     (uses Object.assign internally)
for (const k in styles.image)    // → never executes
```

Any third-party component that isn't wrapped by the unistyles Babel plugin receives these broken style objects. The most impactful case is **expo-image** — all images become completely invisible on web.

## Why this fix is safe

For **wrapped components** (View, Text, etc. from react-native), `createUnistylesElement` already **replaces the entire `style` prop** with CSS class references via `getClassName()`:

```tsx
// createUnistylesElement.tsx
const UnistylesComponent = (props: any) => {
    return <Component {...props} {...buildUnistylesProps(Component, props, props.ref)} />
    //                            ↑ this overwrites props.style with className array
}
```

Since the original style object is completely overridden, the enumerability of its properties has **zero effect** on wrapped components. The non-enumerable trick was unnecessary.

For **non-wrapped components** (expo-image, react-native-svg, custom components), making properties enumerable means they get applied as standard inline styles — the correct fallback behavior.

## Change

```diff
// src/web/utils/unistyle.ts — removeInlineStyles()
 Object.defineProperties(
     returnValue,
     reduceObject(values, (value) => ({
         value,
-        enumerable: false,
+        enumerable: true,
         configurable: true,
     })),
 )
```

## Test plan

- [ ] expo-image `<Image>` displays correctly on web with unistyles styles
- [ ] Standard RN components (View, Text, etc.) still work correctly on web
- [ ] CSS classes are still properly generated and applied on wrapped components
- [ ] Animated styles still work correctly
- [ ] No visual regression on web

## Related

- expo/expo#44843
- expo/expo#44844 (draft PR with workaround on expo-image side)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Adjusted style utilities to mark specific metadata properties as non-enumerable while ensuring other style properties are enumerable. This improves object iteration and serialization behavior, reducing accidental enumeration of internal metadata and enhancing predictability and performance during style processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->