### PR TITLE
fix(web): make style properties enumerable for third-party component compatibility

### DIFF
--- a/packages/unistyles/src/__tests__/remove-inline-styles.spec.ts
+++ b/packages/unistyles/src/__tests__/remove-inline-styles.spec.ts
@@ -1,0 +1,53 @@
+import { removeInlineStyles, UNISTYLES_METADATA_KEYS } from '../web/utils'
+
+describe('removeInlineStyles', () => {
+    it('keeps CSS style properties enumerable', () => {
+        const input = { width: 100, height: 200, backgroundColor: 'red' }
+        const result = removeInlineStyles(input as any)
+
+        // Enumerable — visible to Object.keys, Object.assign, spread, for...in
+        expect(Object.keys(result)).toEqual(expect.arrayContaining(['width', 'height', 'backgroundColor']))
+        expect({ ...result }).toEqual({ width: 100, height: 200, backgroundColor: 'red' })
+        expect(Object.assign({}, result)).toEqual({ width: 100, height: 200, backgroundColor: 'red' })
+    })
+
+    it('keeps metadata keys non-enumerable', () => {
+        const input = {
+            width: 100,
+            variants: { size: { large: { width: 200 } } },
+            compoundVariants: [],
+            _web: { cursor: 'pointer' },
+            uni__dependencies: [1, 2],
+            _classNames: 'foo',
+        }
+        const result = removeInlineStyles(input as any)
+
+        const enumKeys = Object.keys(result)
+
+        // CSS property is enumerable
+        expect(enumKeys).toContain('width')
+
+        // Metadata keys are NOT enumerable
+        for (const metaKey of UNISTYLES_METADATA_KEYS) {
+            expect(enumKeys).not.toContain(metaKey)
+        }
+
+        // But metadata keys still exist (accessible via direct access)
+        expect((result as any).variants).toEqual(input.variants)
+        expect((result as any)._web).toEqual(input._web)
+    })
+
+    it('works with StyleSheet.flatten and spread (third-party compat)', () => {
+        const input = {
+            width: '100%',
+            height: 300,
+            variants: { color: { red: { backgroundColor: 'red' } } },
+        }
+        const result = removeInlineStyles(input as any)
+
+        // Simulates what StyleSheet.flatten / Object.assign does
+        const flattened = Object.assign({}, result)
+        expect(flattened).toEqual({ width: '100%', height: 300 })
+        expect(flattened).not.toHaveProperty('variants')
+    })
+})

--- a/packages/unistyles/src/__tests__/remove-inline-styles.spec.ts
+++ b/packages/unistyles/src/__tests__/remove-inline-styles.spec.ts
@@ -50,4 +50,48 @@ describe('removeInlineStyles', () => {
         expect(flattened).toEqual({ width: '100%', height: 300 })
         expect(flattened).not.toHaveProperty('variants')
     })
+
+    it('merges _web CSS properties as enumerable', () => {
+        const input = {
+            width: 100,
+            _web: {
+                cursor: 'pointer',
+                userSelect: 'none',
+            },
+        }
+        const result = removeInlineStyles(input as any)
+
+        const enumKeys = Object.keys(result)
+
+        // _web container stays non-enumerable
+        expect(enumKeys).not.toContain('_web')
+
+        // But _web CSS properties are merged as enumerable
+        expect(enumKeys).toContain('cursor')
+        expect(enumKeys).toContain('userSelect')
+        expect({ ...result }).toEqual({ width: 100, cursor: 'pointer', userSelect: 'none' })
+    })
+
+    it('does not merge _web pseudo selectors or _classNames', () => {
+        const input = {
+            width: 100,
+            _web: {
+                cursor: 'pointer',
+                _classNames: 'custom-class',
+                _hover: { opacity: 0.8 },
+                _focus: { outline: 'none' },
+            },
+        }
+        const result = removeInlineStyles(input as any)
+
+        const enumKeys = Object.keys(result)
+
+        // CSS property from _web is merged
+        expect(enumKeys).toContain('cursor')
+
+        // Pseudo selectors and _classNames are NOT merged
+        expect(enumKeys).not.toContain('_classNames')
+        expect(enumKeys).not.toContain('_hover')
+        expect(enumKeys).not.toContain('_focus')
+    })
 })

--- a/packages/unistyles/src/web/convert/index.ts
+++ b/packages/unistyles/src/web/convert/index.ts
@@ -2,6 +2,7 @@ import type { UnistylesValues } from '../../types'
 import type { UnistylesRuntime } from '../runtime'
 
 import { deepMergeObjects } from '../../utils'
+import { UNISTYLES_METADATA_KEYS } from '../utils'
 import { getBoxShadow, getFilterStyle, getTransformStyle } from './object'
 import { isPseudo } from './pseudo'
 import { getBoxShadowStyle, getTextShadowStyle } from './shadow'
@@ -17,7 +18,7 @@ export const convertUnistyles = (value: UnistylesValues, runtime: UnistylesRunti
     const stylesArray = Object.entries(value).flatMap(([unistylesKey, unistylesValue]) => {
         // Keys to omit
         if (
-            ['_classNames', '_web', 'variants', 'compoundVariants', 'uni__dependencies'].includes(unistylesKey) ||
+            UNISTYLES_METADATA_KEYS.has(unistylesKey) ||
             unistylesKey.startsWith('unistyles_')
         ) {
             return []

--- a/packages/unistyles/src/web/utils/unistyle.ts
+++ b/packages/unistyles/src/web/utils/unistyle.ts
@@ -58,14 +58,16 @@ export const extractSecrets = (object: any) => {
     return reduceObject(Object.getOwnPropertyDescriptors(secrets), (secret) => secret.value)
 }
 
+const UNISTYLES_METADATA_KEYS = new Set(['variants', 'compoundVariants', '_web', 'uni__dependencies', '_classNames'])
+
 export const removeInlineStyles = (values: UnistylesValues) => {
     const returnValue = {}
 
     Object.defineProperties(
         returnValue,
-        reduceObject(values, (value) => ({
+        reduceObject(values, (value, key) => ({
             value,
-            enumerable: false,
+            enumerable: !UNISTYLES_METADATA_KEYS.has(key as string),
             configurable: true,
         })),
     )

--- a/packages/unistyles/src/web/utils/unistyle.ts
+++ b/packages/unistyles/src/web/utils/unistyle.ts
@@ -77,6 +77,25 @@ export const removeInlineStyles = (values: UnistylesValues) => {
         })),
     )
 
+    // Merge web-only CSS properties (cursor, userSelect, etc.) as enumerable
+    // so third-party components that use Object.assign/spread can access them.
+    // This mirrors what shadowRegistry.addStyles does for wrapped components:
+    //   { ...resultWithVariants, ...resultWithVariants._web }
+    const webStyles = (values as any)?._web
+    if (webStyles && typeof webStyles === 'object') {
+        for (const webKey of Object.keys(webStyles)) {
+            // Skip internal keys (_classNames) and pseudo selectors (_hover, _focus, etc.)
+            if (webKey === '_classNames' || webKey.startsWith('_')) {
+                continue
+            }
+            Object.defineProperty(returnValue, webKey, {
+                value: webStyles[webKey],
+                enumerable: true,
+                configurable: true,
+            })
+        }
+    }
+
     return returnValue
 }
 

--- a/packages/unistyles/src/web/utils/unistyle.ts
+++ b/packages/unistyles/src/web/utils/unistyle.ts
@@ -58,7 +58,12 @@ export const extractSecrets = (object: any) => {
     return reduceObject(Object.getOwnPropertyDescriptors(secrets), (secret) => secret.value)
 }
 
-const UNISTYLES_METADATA_KEYS = new Set(['variants', 'compoundVariants', '_web', 'uni__dependencies', '_classNames'])
+/**
+ * Internal metadata keys that should not be treated as CSS style properties.
+ * Used to filter out unistyles-specific keys when exposing styles to
+ * third-party components and when converting styles to CSS.
+ */
+export const UNISTYLES_METADATA_KEYS = new Set(['variants', 'compoundVariants', '_web', 'uni__dependencies', '_classNames'])
 
 export const removeInlineStyles = (values: UnistylesValues) => {
     const returnValue = {}


### PR DESCRIPTION
## Summary

Fixes #1165

Third-party components like `expo-image` are **completely invisible on web** because `removeInlineStyles()` makes all style properties non-enumerable.

## The problem

In `src/web/utils/unistyle.ts`, `removeInlineStyles()` uses `Object.defineProperties` with `enumerable: false` on **all** properties. Standard JS APIs skip non-enumerable properties:

```js
const styles = StyleSheet.create({ image: { width: '100%', height: 300 } });

Object.keys(styles.image)        // → []     (empty)
Object.assign({}, styles.image)  // → {}     (empty)
{ ...styles.image }              // → {}     (empty)
StyleSheet.flatten(styles.image) // → {}     (uses Object.assign internally)
```

Any component not wrapped by the unistyles Babel plugin (expo-image, react-native-svg, etc.) receives these empty-looking style objects → renders at 0×0 → invisible.

## The fix

Selectively set `enumerable` based on whether the key is a CSS style property or internal unistyles metadata:

```diff
+const UNISTYLES_METADATA_KEYS = new Set([
+    'variants', 'compoundVariants', '_web', 'uni__dependencies', '_classNames'
+])
+
 export const removeInlineStyles = (values: UnistylesValues) => {
     const returnValue = {}
     Object.defineProperties(
         returnValue,
-        reduceObject(values, (value) => ({
+        reduceObject(values, (value, key) => ({
             value,
-            enumerable: false,
+            enumerable: !UNISTYLES_METADATA_KEYS.has(key as string),
             configurable: true,
         })),
     )
     return returnValue
 }
```

- **CSS properties** (width, height, flex, etc.) → `enumerable: true` — visible to third-party components
- **Internal metadata** (variants, compoundVariants, _web, uni__dependencies, _classNames) → `enumerable: false` — hidden from third-party components

## Why this is safe for wrapped components

`createUnistylesElement` **replaces the entire `style` prop** with CSS class references via `getClassName()`:

```tsx
// createUnistylesElement.tsx
const UnistylesComponent = (props: any) => {
    return <Component {...props} {...buildUnistylesProps(Component, props, props.ref)} />
    //                            ↑ overwrites props.style with className array
}
```

Since the original style object is completely overridden for wrapped components, the enumerability of its properties has **zero effect** on View, Text, etc.

## Tested on

- Expo app with expo-image ~2.4.1 + unistyles ^3.2.3
- Verified images display correctly on web with this fix
- Verified no visual regression on wrapped components (View, Text, etc.)

## Related

- expo/expo#44843
- expo/expo#44844 (draft PR — workaround on expo-image side, no longer needed with this fix)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated style handling so plain CSS properties are exposed normally when styles are flattened or spread, while internal metadata stays hidden—improves compatibility with third‑party tools and predictable enumeration.
  * Web-only style properties are now merged into the visible style output, while internal class/selector entries remain excluded.

* **Tests**
  * Added tests validating enumerable style properties, hidden metadata keys, safe flattening, and correct handling of web-only versus internal entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->