### PR TITLE
fix: no ime updates in withUnistyles wrapped components

### DIFF
--- a/packages/unistyles/cxx/hybridObjects/HybridStyleSheet.cpp
+++ b/packages/unistyles/cxx/hybridObjects/HybridStyleSheet.cpp
@@ -271,33 +271,9 @@ void HybridStyleSheet::onPlatformDependenciesChange(std::vector<UnistyleDependen
             return;
         }
 
-        auto& registry = core::UnistylesRegistry::get();
-        auto parser = parser::Parser(self->_unistylesRuntime);
         auto unistyleDependencies = dependencies;
-        auto dependencyMap = registry.buildDependencyMap(unistyleDependencies);
 
-        // in a later step, we will rebuild only Unistyles with mounted StyleSheets
-        // however, user may have StyleSheets with components that haven't mounted yet
-        // we need to rebuild all dependent StyleSheets as well
-        auto dependentStyleSheets = registry.getStyleSheetsToRefresh(unistyleDependencies);
-
-        if (dependencyMap.empty() && dependentStyleSheets.empty()) {
-            return;
-        }
-
-        // rebuild rawValue for all affected unistyles BEFORE notifying listeners
-        // so JS consumers (withUnistyles) re-render with fresh closures
-        parser.rebuildUnistylesInDependencyMap(rt, dependencyMap, dependentStyleSheets, std::nullopt);
-
-        if (!dependencyMap.empty()) {
-            parser.rebuildShadowLeafUpdates(rt, dependencyMap);
-        }
-
-        self->notifyJSListeners(unistyleDependencies);
-
-        if (!dependencyMap.empty()) {
-            shadow::ShadowTreeManager::updateShadowTree(rt);
-        }
+        self->applyDependencyChanges(rt, unistyleDependencies, std::nullopt);
     });
 }
 
@@ -317,7 +293,6 @@ void HybridStyleSheet::onPlatformNativeDependenciesChange(std::vector<UnistyleDe
         }
 
         auto& registry = core::UnistylesRegistry::get();
-        auto parser = parser::Parser(self->_unistylesRuntime);
         auto unistyleDependencies = std::move(dependencies);
 
         // re-compute new breakpoint
@@ -340,30 +315,7 @@ void HybridStyleSheet::onPlatformNativeDependenciesChange(std::vector<UnistyleDe
             self->_unistylesRuntime->includeDependenciesForColorSchemeChange(unistyleDependencies);
         }
 
-        auto dependencyMap = registry.buildDependencyMap(unistyleDependencies);
-
-        // in a later step, we will rebuild only Unistyles with mounted StyleSheets
-        // however, user may have StyleSheets with components that haven't mounted yet
-        // we need to rebuild all dependent StyleSheets as well
-        auto dependentStyleSheets = registry.getStyleSheetsToRefresh(unistyleDependencies);
-
-        if (dependencyMap.empty() && dependentStyleSheets.empty()) {
-            return;
-        }
-
-        // rebuild rawValue for all affected unistyles BEFORE notifying listeners
-        // so JS consumers (withUnistyles) re-render with fresh closures
-        parser.rebuildUnistylesInDependencyMap(rt, dependencyMap, dependentStyleSheets, miniRuntime);
-
-        if (!dependencyMap.empty()) {
-            parser.rebuildShadowLeafUpdates(rt, dependencyMap);
-        }
-
-        self->notifyJSListeners(unistyleDependencies);
-
-        if (!dependencyMap.empty()) {
-            shadow::ShadowTreeManager::updateShadowTree(rt);
-        }
+        self->applyDependencyChanges(rt, unistyleDependencies, miniRuntime);
     });
 }
 
@@ -382,30 +334,36 @@ void HybridStyleSheet::onImeChange(UnistylesNativeMiniRuntime miniRuntime) {
         }
 
         std::vector<UnistyleDependency> dependencies{UnistyleDependency::IME};
-        auto& registry = core::UnistylesRegistry::get();
-        auto parser = parser::Parser(self->_unistylesRuntime);
-        auto dependencyMap = registry.buildDependencyMap(dependencies);
 
-        // include StyleSheets consumed only by JS (withUnistyles) - they aren't in dependencyMap
-        // but their rawValue must still be refreshed so rerenders read fresh closures
-        auto dependentStyleSheets = registry.getStyleSheetsToRefresh(dependencies);
-
-        if (dependencyMap.empty() && dependentStyleSheets.empty()) {
-            return;
-        }
-
-        parser.rebuildUnistylesInDependencyMap(rt, dependencyMap, dependentStyleSheets, miniRuntime);
-
-        if (!dependencyMap.empty()) {
-            parser.rebuildShadowLeafUpdates(rt, dependencyMap);
-        }
-
-        self->notifyJSListeners(dependencies);
-
-        if (!dependencyMap.empty()) {
-            shadow::ShadowTreeManager::updateShadowTree(rt);
-        }
+        self->applyDependencyChanges(rt, dependencies, miniRuntime);
     });
+}
+
+void HybridStyleSheet::applyDependencyChanges(jsi::Runtime& rt, std::vector<UnistyleDependency>& dependencies, std::optional<UnistylesNativeMiniRuntime> maybeMiniRuntime) {
+    auto& registry = core::UnistylesRegistry::get();
+    auto parser = parser::Parser(this->_unistylesRuntime);
+    auto dependencyMap = registry.buildDependencyMap(dependencies);
+
+    // include StyleSheets consumed only by JS (withUnistyles) — they aren't in dependencyMap
+    // but their rawValue must still be refreshed so rerenders read fresh closures
+    auto dependentStyleSheets = registry.getStyleSheetsToRefresh(dependencies);
+
+    if (dependencyMap.empty() && dependentStyleSheets.empty()) {
+        return;
+    }
+
+    // rebuild rawValue BEFORE notifying listeners so JS rerenders read fresh closures
+    parser.rebuildUnistylesInDependencyMap(rt, dependencyMap, dependentStyleSheets, maybeMiniRuntime);
+
+    if (!dependencyMap.empty()) {
+        parser.rebuildShadowLeafUpdates(rt, dependencyMap);
+    }
+
+    this->notifyJSListeners(dependencies);
+
+    if (!dependencyMap.empty()) {
+        shadow::ShadowTreeManager::updateShadowTree(rt);
+    }
 }
 
 void HybridStyleSheet::notifyJSListeners(std::vector<UnistyleDependency>& dependencies) {

--- a/packages/unistyles/cxx/hybridObjects/HybridStyleSheet.cpp
+++ b/packages/unistyles/cxx/hybridObjects/HybridStyleSheet.cpp
@@ -276,27 +276,28 @@ void HybridStyleSheet::onPlatformDependenciesChange(std::vector<UnistyleDependen
         auto unistyleDependencies = dependencies;
         auto dependencyMap = registry.buildDependencyMap(unistyleDependencies);
 
-        if (dependencyMap.empty()) {
-            self->notifyJSListeners(unistyleDependencies);
-        }
-
         // in a later step, we will rebuild only Unistyles with mounted StyleSheets
         // however, user may have StyleSheets with components that haven't mounted yet
         // we need to rebuild all dependent StyleSheets as well
         auto dependentStyleSheets = registry.getStyleSheetsToRefresh(unistyleDependencies);
 
-        parser.rebuildUnistylesInDependencyMap(rt, dependencyMap, dependentStyleSheets, std::nullopt);
-
-        // we need to stop here if there is nothing to update at the moment,
-        // but we need to compute dependentStyleSheets
-        if (dependencyMap.empty()) {
+        if (dependencyMap.empty() && dependentStyleSheets.empty()) {
             return;
         }
 
-        parser.rebuildShadowLeafUpdates(rt, dependencyMap);
+        // rebuild rawValue for all affected unistyles BEFORE notifying listeners
+        // so JS consumers (withUnistyles) re-render with fresh closures
+        parser.rebuildUnistylesInDependencyMap(rt, dependencyMap, dependentStyleSheets, std::nullopt);
+
+        if (!dependencyMap.empty()) {
+            parser.rebuildShadowLeafUpdates(rt, dependencyMap);
+        }
 
         self->notifyJSListeners(unistyleDependencies);
-        shadow::ShadowTreeManager::updateShadowTree(rt);
+
+        if (!dependencyMap.empty()) {
+            shadow::ShadowTreeManager::updateShadowTree(rt);
+        }
     });
 }
 
@@ -341,27 +342,28 @@ void HybridStyleSheet::onPlatformNativeDependenciesChange(std::vector<UnistyleDe
 
         auto dependencyMap = registry.buildDependencyMap(unistyleDependencies);
 
-        if (dependencyMap.empty()) {
-            self->notifyJSListeners(unistyleDependencies);
-        }
-
         // in a later step, we will rebuild only Unistyles with mounted StyleSheets
         // however, user may have StyleSheets with components that haven't mounted yet
         // we need to rebuild all dependent StyleSheets as well
         auto dependentStyleSheets = registry.getStyleSheetsToRefresh(unistyleDependencies);
 
-        parser.rebuildUnistylesInDependencyMap(rt, dependencyMap, dependentStyleSheets, miniRuntime);
-
-        // we need to stop here if there is nothing to update at the moment,
-        // but we need to compute dependentStyleSheets
-        if (dependencyMap.empty()) {
+        if (dependencyMap.empty() && dependentStyleSheets.empty()) {
             return;
         }
 
-        parser.rebuildShadowLeafUpdates(rt, dependencyMap);
+        // rebuild rawValue for all affected unistyles BEFORE notifying listeners
+        // so JS consumers (withUnistyles) re-render with fresh closures
+        parser.rebuildUnistylesInDependencyMap(rt, dependencyMap, dependentStyleSheets, miniRuntime);
+
+        if (!dependencyMap.empty()) {
+            parser.rebuildShadowLeafUpdates(rt, dependencyMap);
+        }
 
         self->notifyJSListeners(unistyleDependencies);
-        shadow::ShadowTreeManager::updateShadowTree(rt);
+
+        if (!dependencyMap.empty()) {
+            shadow::ShadowTreeManager::updateShadowTree(rt);
+        }
     });
 }
 
@@ -384,21 +386,25 @@ void HybridStyleSheet::onImeChange(UnistylesNativeMiniRuntime miniRuntime) {
         auto parser = parser::Parser(self->_unistylesRuntime);
         auto dependencyMap = registry.buildDependencyMap(dependencies);
 
-        if (dependencyMap.empty()) {
-            self->notifyJSListeners(dependencies);
+        // include StyleSheets consumed only by JS (withUnistyles) - they aren't in dependencyMap
+        // but their rawValue must still be refreshed so rerenders read fresh closures
+        auto dependentStyleSheets = registry.getStyleSheetsToRefresh(dependencies);
 
+        if (dependencyMap.empty() && dependentStyleSheets.empty()) {
             return;
         }
 
-        // we don't care about other unmounted stylesheets as their not visible
-        // so user won't see any changes
-        std::vector<std::shared_ptr<core::StyleSheet>> dependentStyleSheets;
-
         parser.rebuildUnistylesInDependencyMap(rt, dependencyMap, dependentStyleSheets, miniRuntime);
-        parser.rebuildShadowLeafUpdates(rt, dependencyMap);
+
+        if (!dependencyMap.empty()) {
+            parser.rebuildShadowLeafUpdates(rt, dependencyMap);
+        }
 
         self->notifyJSListeners(dependencies);
-        shadow::ShadowTreeManager::updateShadowTree(rt);
+
+        if (!dependencyMap.empty()) {
+            shadow::ShadowTreeManager::updateShadowTree(rt);
+        }
     });
 }
 

--- a/packages/unistyles/cxx/hybridObjects/HybridStyleSheet.h
+++ b/packages/unistyles/cxx/hybridObjects/HybridStyleSheet.h
@@ -3,6 +3,7 @@
 #include <cmath>
 #include <jsi/jsi.h>
 #include <mutex>
+#include <optional>
 #include <unordered_map>
 #include "HybridUnistylesRuntime.h"
 #include "HybridUnistylesStyleSheetSpec.hpp"
@@ -69,6 +70,7 @@ private:
     void onPlatformDependenciesChange(std::vector<UnistyleDependency> dependencies);
     void onPlatformNativeDependenciesChange(std::vector<UnistyleDependency> dependencies, UnistylesNativeMiniRuntime miniRuntime);
     void onImeChange(UnistylesNativeMiniRuntime miniRuntime);
+    void applyDependencyChanges(jsi::Runtime& rt, std::vector<UnistyleDependency>& dependencies, std::optional<UnistylesNativeMiniRuntime> maybeMiniRuntime);
     void notifyJSListeners(std::vector<UnistyleDependency>& dependencies);
 
     bool isInitialized = false;


### PR DESCRIPTION
## Summary

Fixes #1162 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved style sheet update reliability so input method (IME) changes and other dependency updates consistently refresh affected styles.
  * Ensures JS-driven style changes trigger necessary UI refreshes even when native dependency sets appear empty.

* **Refactor**
  * Centralized dependency-change handling to make updates more predictable and reduce missed refreshes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->