### PR TITLE
fix: components wrapped in withUnistyles don't follow ScopedTheme

### DIFF
--- a/packages/unistyles/cxx/core/UnistyleWrapper.h
+++ b/packages/unistyles/cxx/core/UnistyleWrapper.h
@@ -171,10 +171,12 @@ inline static jsi::Value objectFromUnistyle(jsi::Runtime& rt, std::shared_ptr<Hy
             auto parser = parser::Parser(unistylesRuntime);
             auto parsedStyleSheet = parser.getParsedStyleSheetForScopedTheme(rt, unistyle, scopedTheme.value());
 
-            parser.rebuildUnistyleWithScopedTheme(rt, parsedStyleSheet, unistyleData);
+            if (!parsedStyleSheet.isUndefined()) {
+                parser.rebuildUnistyleWithScopedTheme(rt, parsedStyleSheet, unistyleData);
 
-            if (unistyleData->parsedStyle.has_value()) {
-                return jsi::Value(rt, unistyleData->parsedStyle.value()).asObject(rt);
+                if (unistyleData->parsedStyle.has_value()) {
+                    return jsi::Value(rt, unistyleData->parsedStyle.value()).asObject(rt);
+                }
             }
         }
 

--- a/packages/unistyles/cxx/core/UnistyleWrapper.h
+++ b/packages/unistyles/cxx/core/UnistyleWrapper.h
@@ -159,6 +159,7 @@ inline static jsi::Value objectFromUnistyle(jsi::Runtime& rt, std::shared_ptr<Hy
         auto& registry = UnistylesRegistry::get();
         auto unistyle = registry.getUnistyleById(unistyleID);
         auto scopedTheme = registry.getScopedTheme();
+        parser::Parser parser(unistylesRuntime);
 
         // scoped theme path — parse with scope so `withUnistyles`-wrapped
         // components inside <ScopedTheme> reflect the scope instead of the global theme
@@ -168,7 +169,6 @@ inline static jsi::Value objectFromUnistyle(jsi::Runtime& rt, std::shared_ptr<Hy
                 : std::vector<folly::dynamic>{};
 
             auto unistyleData = std::make_shared<UnistyleData>(unistyle, variants, scopedArguments, scopedTheme);
-            auto parser = parser::Parser(unistylesRuntime);
             auto parsedStyleSheet = parser.getParsedStyleSheetForScopedTheme(rt, unistyle, scopedTheme.value());
 
             if (!parsedStyleSheet.isUndefined()) {
@@ -180,7 +180,7 @@ inline static jsi::Value objectFromUnistyle(jsi::Runtime& rt, std::shared_ptr<Hy
             }
         }
 
-        parser::Parser(unistylesRuntime).rebuildUnistyle(rt, unistyle, variants, parsedArguments);
+        parser.rebuildUnistyle(rt, unistyle, variants, parsedArguments);
 
         return jsi::Value(rt, unistyle->parsedStyle.value()).asObject(rt);
     });

--- a/packages/unistyles/cxx/core/UnistyleWrapper.h
+++ b/packages/unistyles/cxx/core/UnistyleWrapper.h
@@ -158,6 +158,25 @@ inline static jsi::Value objectFromUnistyle(jsi::Runtime& rt, std::shared_ptr<Hy
     ) {
         auto& registry = UnistylesRegistry::get();
         auto unistyle = registry.getUnistyleById(unistyleID);
+        auto scopedTheme = registry.getScopedTheme();
+
+        // scoped theme path — parse with scope so `withUnistyles`-wrapped
+        // components inside <ScopedTheme> reflect the scope instead of the global theme
+        if (scopedTheme.has_value() && unistyle->styleKey != helpers::EXOTIC_STYLE_KEY) {
+            std::vector<folly::dynamic> scopedArguments = parsedArguments.has_value()
+                ? parsedArguments.value()
+                : std::vector<folly::dynamic>{};
+
+            auto unistyleData = std::make_shared<UnistyleData>(unistyle, variants, scopedArguments, scopedTheme);
+            auto parser = parser::Parser(unistylesRuntime);
+            auto parsedStyleSheet = parser.getParsedStyleSheetForScopedTheme(rt, unistyle, scopedTheme.value());
+
+            parser.rebuildUnistyleWithScopedTheme(rt, parsedStyleSheet, unistyleData);
+
+            if (unistyleData->parsedStyle.has_value()) {
+                return jsi::Value(rt, unistyleData->parsedStyle.value()).asObject(rt);
+            }
+        }
 
         parser::Parser(unistylesRuntime).rebuildUnistyle(rt, unistyle, variants, parsedArguments);
 


### PR DESCRIPTION
## Summary

Fixes #1171

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved theme application so scoped themes are attempted before the global rebuild. When a compatible scoped theme is present, its styles are applied immediately; if not, the system falls back to the previous global style rebuild. This ensures scoped styling is correctly used when available while preserving prior behavior otherwise.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->