### PR TITLE
fix: platform color in variants doesnt work

### DIFF
--- a/packages/unistyles/cxx/parser/Parser.cpp
+++ b/packages/unistyles/cxx/parser/Parser.cpp
@@ -494,7 +494,7 @@ jsi::Object parser::Parser::parseFirstLevel(jsi::Runtime& rt, Unistyle::Shared u
 
             return;
         }
-        
+
         if (propertyValue.isBool() && propertyName == "includeFontPadding") {
             parsedStyle.setProperty(rt, jsi::PropNameID::forUtf8(rt, propertyName), propertyValue);
 
@@ -1004,6 +1004,15 @@ jsi::Value parser::Parser::parseSecondLevel(jsi::Runtime &rt, Unistyle::Shared u
 
         if (nestedObjectStyle.isFunction(rt)) {
             parsedStyle.setProperty(rt, propertyName.c_str(), jsi::Value::undefined());
+
+            return;
+        }
+
+        // PlatformColor / DynamicColorIOS / Android ColorResource objects must
+        // pass through unchanged — otherwise getValueFromBreakpoints treats them
+        // as a breakpoint map and strips the color
+        if (helpers::isPlatformColor(rt, nestedObjectStyle)) {
+            parsedStyle.setProperty(rt, propertyName.c_str(), propertyValue);
 
             return;
         }


### PR DESCRIPTION
## Summary

Fixes #1174 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed color resource parsing to correctly preserve platform and dynamic color resource objects without applying unintended transformations during resolution
  * Improved handling of dynamic color resources across the styling pipeline to maintain object integrity
  * Enhanced color resource reliability throughout the application

<!-- end of auto-generated comment: release notes by coderabbit.ai -->