### PR TITLE
fix(web): add fallback for screen orientation API

### DIFF
--- a/packages/unistyles/src/web/runtime.ts
+++ b/packages/unistyles/src/web/runtime.ts
@@ -80,7 +80,13 @@ export class UnistylesRuntime {
             return Orientation.Portrait
         }
 
-        return screen.orientation.type.includes('portrait') ? Orientation.Portrait : Orientation.Landscape
+        const orientationType = window.screen.orientation?.type
+
+        if (orientationType) {
+            return orientationType.includes('portrait') ? Orientation.Portrait : Orientation.Landscape
+        }
+
+        return window.innerHeight >= window.innerWidth ? Orientation.Portrait : Orientation.Landscape
     }
 
     get isLandscape() {


### PR DESCRIPTION
## Summary

Fixed a web runtime crash caused by accessing `screen.orientation.type` directly in browsers that don’t support the [Screen Orientation API](https://developer.mozilla.org/en-US/docs/Web/API/ScreenOrientation/type), which affected primarily users  running older versions of iOS. The runtime now safely checks for `window.screen.orientation?.type` and falls back to comparing `window.innerHeight` and `window.innerWidth` to infer portrait vs landscape orientation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved device orientation detection robustness by adding a fallback mechanism, ensuring the app correctly identifies portrait and landscape orientations across more devices and browsers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->