### PR TITLE
feat: don't parse static StyleSheet.create, add excludePaths plugin option

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -99,7 +99,7 @@
     },
     "packages/unistyles": {
       "name": "react-native-unistyles",
-      "version": "3.2.3",
+      "version": "3.2.4",
       "dependencies": {
         "@babel/types": "7.29.0",
       },

--- a/packages/unistyles/plugin/__tests__/excludePaths.spec.tsx
+++ b/packages/unistyles/plugin/__tests__/excludePaths.spec.tsx
@@ -1,0 +1,185 @@
+import { pluginTester } from 'babel-plugin-tester'
+
+import plugin from '../src/index'
+
+pluginTester({
+    plugin,
+    pluginOptions: {
+        debug: false,
+        root: 'src',
+        excludePaths: ['src/constants', 'src/tokens'],
+    },
+    babelOptions: {
+        plugins: ['@babel/plugin-syntax-jsx'],
+        generatorOpts: {
+            retainLines: true,
+        },
+    },
+    tests: [
+        {
+            title: 'Should leave a static StyleSheet.create completely untouched when its file matches excludePaths',
+            babelOptions: {
+                filename: '/project/src/constants/styles.ts',
+            },
+            code: `
+                import { StyleSheet } from 'react-native-unistyles'
+
+                const styles = StyleSheet.create({
+                    container: {
+                        flex: 1,
+                        backgroundColor: '#fff'
+                    }
+                })
+            `,
+            output: `
+                import { StyleSheet } from 'react-native-unistyles'
+
+                const styles = StyleSheet.create({
+                    container: {
+                        flex: 1,
+                        backgroundColor: '#fff'
+                    }
+                })
+            `,
+        },
+        {
+            title: 'Should not rewrite RN component imports when file matches excludePaths',
+            babelOptions: {
+                filename: '/project/src/constants/layout.tsx',
+            },
+            code: `
+                import { View, Text } from 'react-native'
+                import { StyleSheet } from 'react-native-unistyles'
+
+                export const Layout = () => {
+                    return (
+                        <View>
+                            <Text>hello</Text>
+                        </View>
+                    )
+                }
+
+                const styles = StyleSheet.create({
+                    container: {
+                        flex: 1
+                    }
+                })
+            `,
+            output: `
+                import { View, Text } from 'react-native'
+                import { StyleSheet } from 'react-native-unistyles'
+
+                export const Layout = () => {
+                    return (
+                        <View>
+                            <Text>hello</Text>
+                        </View>
+                    )
+                }
+
+                const styles = StyleSheet.create({
+                    container: {
+                        flex: 1
+                    }
+                })
+            `,
+        },
+        {
+            title: 'Should not inject uni__dependencies when file matches excludePaths, even with theme usage',
+            babelOptions: {
+                filename: '/project/src/tokens/typography.ts',
+            },
+            code: `
+                import { StyleSheet } from 'react-native-unistyles'
+
+                const styles = StyleSheet.create(theme => ({
+                    text: {
+                        color: theme.colors.primary,
+                        fontSize: 14
+                    }
+                }))
+            `,
+            output: `
+                import { StyleSheet } from 'react-native-unistyles'
+
+                const styles = StyleSheet.create(theme => ({
+                    text: {
+                        color: theme.colors.primary,
+                        fontSize: 14
+                    }
+                }))
+            `,
+        },
+        {
+            title: 'Should still fully process files in root that do NOT match excludePaths',
+            babelOptions: {
+                filename: '/project/src/components/Button.tsx',
+            },
+            code: `
+                import { View, Text } from 'react-native'
+                import { StyleSheet } from 'react-native-unistyles'
+
+                export const Button = () => {
+                    return (
+                        <View>
+                            <Text>Click me</Text>
+                        </View>
+                    )
+                }
+
+                const styles = StyleSheet.create(theme => ({
+                    container: {
+                        backgroundColor: theme.colors.primary
+                    }
+                }))
+            `,
+            output: `
+                import { Text } from 'react-native-unistyles/components/native/Text'
+                import { View } from 'react-native-unistyles/components/native/View'
+
+                import { StyleSheet } from 'react-native-unistyles'
+
+                export const Button = () => {
+                    return (
+                        <View>
+                            <Text>Click me</Text>
+                        </View>
+                    )
+                }
+
+                const styles = StyleSheet.create(theme => ({
+                    container: {
+                        backgroundColor: theme.colors.primary,
+                        uni__dependencies: [0]
+                    }
+                }))
+            `,
+        },
+        {
+            title: 'Should match excludePaths as a substring across nested directories',
+            babelOptions: {
+                filename: '/project/src/constants/design-tokens/spacing.ts',
+            },
+            code: `
+                import { StyleSheet } from 'react-native-unistyles'
+
+                export const spacing = StyleSheet.create({
+                    base: {
+                        padding: 16,
+                        margin: 8
+                    }
+                })
+            `,
+            output: `
+                import { StyleSheet } from 'react-native-unistyles'
+
+                export const spacing = StyleSheet.create({
+                    base: {
+                        padding: 16,
+                        margin: 8
+                    }
+                })
+            `,
+        },
+    ],
+})

--- a/packages/unistyles/plugin/__tests__/imports.spec.tsx
+++ b/packages/unistyles/plugin/__tests__/imports.spec.tsx
@@ -37,7 +37,7 @@ pluginTester({
             output: `
                 import { View } from 'react-native-custom'
                 import { FlatList } from 'react-native-gesture-handler'
-                import { StyleSheet } from 'react-native-unistyles'
+                import { StyleSheet } from 'react-native'
 
                 export const Example = () => {
                     return <View style={styles.container} />

--- a/packages/unistyles/plugin/__tests__/staticStyleSheet.spec.tsx
+++ b/packages/unistyles/plugin/__tests__/staticStyleSheet.spec.tsx
@@ -1,0 +1,229 @@
+import { pluginTester } from 'babel-plugin-tester'
+
+import plugin from '../src/index'
+
+// These tests verify that files inside `root` which only contain a static
+// StyleSheet.create (no RN component imports, no theme/rt/variants) produce
+// zero AST changes — i.e. forceProcessing no longer triggers on path-match
+// alone; it only activates when a qualifying RN component import is seen.
+//
+// Additionally: when all StyleSheet.create calls in a file are purely static
+// (no uni__dependencies injected), the import is rewritten from
+// 'react-native-unistyles' to 'react-native' so the Unistyles registry is
+// never involved.
+pluginTester({
+    plugin,
+    pluginOptions: {
+        debug: false,
+        root: 'src',
+    },
+    babelOptions: {
+        plugins: ['@babel/plugin-syntax-jsx'],
+        generatorOpts: {
+            retainLines: true,
+        },
+    },
+    tests: [
+        {
+            title: 'Should rewrite StyleSheet import to react-native for a purely static stylesheet',
+            babelOptions: {
+                filename: '/project/src/styles/common.ts',
+            },
+            code: `
+                import { StyleSheet } from 'react-native-unistyles'
+
+                const styles = StyleSheet.create({
+                    container: {
+                        flex: 1,
+                        backgroundColor: '#fff'
+                    }
+                })
+            `,
+            output: `
+                import { StyleSheet } from 'react-native'
+
+                const styles = StyleSheet.create({
+                    container: {
+                        flex: 1,
+                        backgroundColor: '#fff'
+                    }
+                })
+            `,
+        },
+        {
+            title: 'Should rewrite StyleSheet import to react-native for multiple static styles',
+            babelOptions: {
+                filename: '/project/src/styles/layout.ts',
+            },
+            code: `
+                import { StyleSheet } from 'react-native-unistyles'
+
+                export const layoutStyles = StyleSheet.create({
+                    row: {
+                        flexDirection: 'row',
+                        alignItems: 'center'
+                    },
+                    center: {
+                        justifyContent: 'center',
+                        alignItems: 'center'
+                    },
+                    fill: {
+                        flex: 1
+                    }
+                })
+            `,
+            output: `
+                import { StyleSheet } from 'react-native'
+
+                export const layoutStyles = StyleSheet.create({
+                    row: {
+                        flexDirection: 'row',
+                        alignItems: 'center'
+                    },
+                    center: {
+                        justifyContent: 'center',
+                        alignItems: 'center'
+                    },
+                    fill: {
+                        flex: 1
+                    }
+                })
+            `,
+        },
+        {
+            title: 'Should still rewrite RN component imports and keep unistyles StyleSheet when file also has RN components',
+            babelOptions: {
+                filename: '/project/src/components/Card.tsx',
+            },
+            code: `
+                import { View, Text } from 'react-native'
+                import { StyleSheet } from 'react-native-unistyles'
+
+                export const Card = () => (
+                    <View style={styles.container}>
+                        <Text style={styles.title}>Hello</Text>
+                    </View>
+                )
+
+                const styles = StyleSheet.create({
+                    container: {
+                        flex: 1,
+                        padding: 16
+                    },
+                    title: {
+                        fontSize: 18
+                    }
+                })
+            `,
+            output: `
+                import { Text } from 'react-native-unistyles/components/native/Text'
+                import { View } from 'react-native-unistyles/components/native/View'
+
+                import { StyleSheet } from 'react-native-unistyles'
+
+                export const Card = () => (
+                    <View style={styles.container}>
+                        <Text style={styles.title}>Hello</Text>
+                    </View>
+                )
+
+                const styles = StyleSheet.create({
+                    container: {
+                        flex: 1,
+                        padding: 16
+                    },
+                    title: {
+                        fontSize: 18
+                    }
+                })
+            `,
+        },
+        {
+            title: 'Should inject uni__dependencies and keep unistyles import when theme is used',
+            babelOptions: {
+                filename: '/project/src/components/Header.tsx',
+            },
+            code: `
+                import { View } from 'react-native'
+                import { StyleSheet } from 'react-native-unistyles'
+
+                export const Header = () => <View style={styles.header} />
+
+                const styles = StyleSheet.create(theme => ({
+                    header: {
+                        backgroundColor: theme.colors.primary,
+                        height: 64
+                    }
+                }))
+            `,
+            output: `
+                import { View } from 'react-native-unistyles/components/native/View'
+
+                import { StyleSheet } from 'react-native-unistyles'
+
+                export const Header = () => <View style={styles.header} />
+
+                const styles = StyleSheet.create(theme => ({
+                    header: {
+                        backgroundColor: theme.colors.primary,
+                        height: 64,
+                        uni__dependencies: [0]
+                    }
+                }))
+            `,
+        },
+        {
+            title: 'Should rewrite StyleSheet import to react-native for a static zero-arg function stylesheet',
+            babelOptions: {
+                filename: '/project/src/styles/tokens.ts',
+            },
+            code: `
+                import { StyleSheet } from 'react-native-unistyles'
+
+                const styles = StyleSheet.create(() => ({
+                    base: {
+                        padding: 8,
+                        borderRadius: 4
+                    }
+                }))
+            `,
+            output: `
+                import { StyleSheet } from 'react-native'
+
+                const styles = StyleSheet.create(() => ({
+                    base: {
+                        padding: 8,
+                        borderRadius: 4
+                    }
+                }))
+            `,
+        },
+        {
+            title: 'Should split import when StyleSheet is imported alongside other unistyles exports',
+            babelOptions: {
+                filename: '/project/src/styles/mixed.ts',
+            },
+            code: `
+                import { StyleSheet, useStyles } from 'react-native-unistyles'
+
+                const styles = StyleSheet.create({
+                    box: {
+                        width: 100,
+                        height: 100
+                    }
+                })
+            `,
+            output: `
+                import { useStyles } from 'react-native-unistyles'
+                import { StyleSheet } from 'react-native'
+
+                const styles = StyleSheet.create({
+                    box: {
+                        width: 100,
+                        height: 100
+                    }
+                })
+            `,
+        },
+    ],
+})

--- a/packages/unistyles/plugin/__tests__/stylesheet.spec.tsx
+++ b/packages/unistyles/plugin/__tests__/stylesheet.spec.tsx
@@ -495,7 +495,7 @@ pluginTester({
                 })
             `,
             output: `
-                import { StyleSheet } from 'react-native-unistyles'
+                import { StyleSheet } from 'react-native'
                 const styles = StyleSheet.create({
                     map: {},
                     length: {},
@@ -516,7 +516,7 @@ pluginTester({
                 }))
             `,
             output: `
-                import { StyleSheet } from 'react-native-unistyles'
+                import { StyleSheet } from 'react-native'
                 const styles = StyleSheet.create(theme => ({
                     map: {},
                     length: {},

--- a/packages/unistyles/plugin/index.d.ts
+++ b/packages/unistyles/plugin/index.d.ts
@@ -110,6 +110,15 @@ export interface UnistylesPluginOptions {
     autoProcessPaths?: Array<string>
 
     /**
+     * Example: ['src/constants/styles', 'src/tokens']
+     * Skip processing entirely for files whose path includes any of these strings.
+     * Useful for pure-static style files (design tokens, layout constants) that never use
+     * `theme`, `rt`, variants, or RN component imports — so the plugin has nothing to do.
+     * Takes precedence over `root`, `autoProcessImports`, and `autoProcessPaths`.
+     */
+    excludePaths?: Array<string>
+
+    /**
      * In order to list detected dependencies by the Babel plugin you can enable the `debug` flag.
      * It will `console.log` name of the file and component with Unistyles dependencies.
      */

--- a/packages/unistyles/plugin/src/import.ts
+++ b/packages/unistyles/plugin/src/import.ts
@@ -71,6 +71,10 @@ export function isInsideNodeModules(state: UnistylesPluginPass) {
     return state.file.opts.filename?.includes('node_modules') && !state.file.replaceWithUnistyles
 }
 
+export function isExcludedPath(state: UnistylesPluginPass, excludePaths: Array<string>) {
+    return excludePaths.some((p) => state.file.opts.filename?.includes(p))
+}
+
 export function addUnistylesRequire(path: NodePath<t.Program>, state: UnistylesPluginPass) {
     Object.entries(state.reactNativeImports).forEach(([componentName, uniqueName]) => {
         const newRequire = t.variableDeclaration('const', [

--- a/packages/unistyles/plugin/src/index.ts
+++ b/packages/unistyles/plugin/src/index.ts
@@ -59,14 +59,27 @@ export default function (): PluginObj<UnistylesPluginPass> {
                         .map(toPlatformPath)
                         .some((path) => state.filename?.includes(path))
 
+                    state.file.isExcluded = Array.isArray(state.opts.excludePaths)
+                        ? state.opts.excludePaths.map(toPlatformPath).some((p) => state.filename?.includes(p))
+                        : false
+
+                    if (state.file.isExcluded) {
+                        return
+                    }
+
                     state.file.hasAnyUnistyle = false
                     state.file.hasUnistylesImport = false
+                    state.file.hasDynamicStyleSheet = false
                     state.file.addUnistylesRequire = false
                     state.file.hasVariants = false
                     state.file.styleSheetLocalName = ''
                     state.file.reactNativeCommonJSName = ''
                     state.reactNativeImports = {}
-                    state.file.forceProcessing = state.filename?.includes(appRoot) ?? false
+                    // forceProcessing is no longer set eagerly from the path match.
+                    // It is activated in ImportDeclaration when a qualifying RN component
+                    // import is detected — so files that only contain a static StyleSheet.create
+                    // and no RN component imports produce zero output changes.
+                    state.file.forceProcessing = false
 
                     path.traverse({
                         BlockStatement(blockPath) {
@@ -79,12 +92,68 @@ export default function (): PluginObj<UnistylesPluginPass> {
                     })
                 },
                 exit(path, state) {
-                    if (isInsideNodeModules(state)) {
+                    if (state.file.isExcluded || isInsideNodeModules(state)) {
                         return
                     }
 
                     if (state.file.addUnistylesRequire) {
                         return addUnistylesRequire(path, state)
+                    }
+
+                    // If the file imported StyleSheet from react-native-unistyles but every
+                    // StyleSheet.create call was purely static (no uni__dependencies injected),
+                    // rewrite the import source to 'react-native' so the Unistyles registry is
+                    // never involved for this file.
+                    if (
+                        state.file.hasUnistylesImport &&
+                        state.file.styleSheetLocalName &&
+                        !state.file.hasDynamicStyleSheet &&
+                        !state.file.forceProcessing &&
+                        !state.file.replaceWithUnistyles
+                    ) {
+                        path.node.body.forEach((node) => {
+                            if (
+                                t.isImportDeclaration(node) &&
+                                node.source.value === 'react-native-unistyles' &&
+                                node.specifiers.some(
+                                    (s) =>
+                                        t.isImportSpecifier(s) &&
+                                        t.isIdentifier(s.imported) &&
+                                        s.imported.name === 'StyleSheet',
+                                )
+                            ) {
+                                // Collect any non-StyleSheet specifiers that should stay on unistyles
+                                const otherSpecifiers = node.specifiers.filter(
+                                    (s) =>
+                                        !(
+                                            t.isImportSpecifier(s) &&
+                                            t.isIdentifier(s.imported) &&
+                                            s.imported.name === 'StyleSheet'
+                                        ),
+                                )
+                                const styleSheetSpecifiers = node.specifiers.filter(
+                                    (s) =>
+                                        t.isImportSpecifier(s) &&
+                                        t.isIdentifier(s.imported) &&
+                                        s.imported.name === 'StyleSheet',
+                                )
+
+                                if (otherSpecifiers.length > 0) {
+                                    // Keep unistyles import for other named exports; add separate RN import
+                                    node.specifiers = otherSpecifiers
+                                    const rnImport = t.importDeclaration(
+                                        styleSheetSpecifiers,
+                                        t.stringLiteral('react-native'),
+                                    )
+                                    path.node.body.splice(path.node.body.indexOf(node) + 1, 0, rnImport)
+                                } else {
+                                    // Only StyleSheet was imported — rewrite the source in place
+                                    node.source = t.stringLiteral('react-native')
+                                }
+                            }
+                        })
+
+                        return
                     }
 
                     if (
@@ -98,7 +167,7 @@ export default function (): PluginObj<UnistylesPluginPass> {
                 },
             },
             FunctionDeclaration(path, state) {
-                if (isInsideNodeModules(state)) {
+                if (state.file.isExcluded || isInsideNodeModules(state)) {
                     return
                 }
 
@@ -109,7 +178,7 @@ export default function (): PluginObj<UnistylesPluginPass> {
                 }
             },
             ClassDeclaration(path, state) {
-                if (isInsideNodeModules(state)) {
+                if (state.file.isExcluded || isInsideNodeModules(state)) {
                     return
                 }
 
@@ -120,7 +189,7 @@ export default function (): PluginObj<UnistylesPluginPass> {
                 }
             },
             VariableDeclaration(path, state) {
-                if (isInsideNodeModules(state)) {
+                if (state.file.isExcluded || isInsideNodeModules(state)) {
                     return
                 }
 
@@ -136,6 +205,10 @@ export default function (): PluginObj<UnistylesPluginPass> {
                 })
             },
             ImportDeclaration(path, state) {
+                if (state.file.isExcluded) {
+                    return
+                }
+
                 const exoticImport = REPLACE_WITH_UNISTYLES_EXOTIC_PATHS.concat(state.opts.autoRemapImports ?? []).find(
                     (exotic) => state.filename?.includes(exotic.path),
                 )
@@ -172,6 +245,9 @@ export default function (): PluginObj<UnistylesPluginPass> {
                             REACT_NATIVE_COMPONENT_NAMES.includes(specifier.imported.name)
                         ) {
                             state.reactNativeImports[specifier.local.name] = specifier.imported.name
+                            // activate forceProcessing only when there are actual RN components
+                            // to rewrite — not just because the file is inside root
+                            state.file.forceProcessing = true
                         }
                     })
                 }
@@ -185,7 +261,7 @@ export default function (): PluginObj<UnistylesPluginPass> {
                 }
             },
             JSXElement(path, state) {
-                if (isInsideNodeModules(state)) {
+                if (state.file.isExcluded || isInsideNodeModules(state)) {
                     return
                 }
 
@@ -194,7 +270,7 @@ export default function (): PluginObj<UnistylesPluginPass> {
                 }
             },
             MemberExpression(path, state) {
-                if (isInsideNodeModules(state)) {
+                if (state.file.isExcluded || isInsideNodeModules(state)) {
                     return
                 }
 
@@ -225,7 +301,7 @@ export default function (): PluginObj<UnistylesPluginPass> {
                 path.node.object.name = state.reactNativeImports[path.node.property.name] as string
             },
             CallExpression(path, state) {
-                if (isInsideNodeModules(state)) {
+                if (state.file.isExcluded || isInsideNodeModules(state)) {
                     return
                 }
 

--- a/packages/unistyles/plugin/src/stylesheet.ts
+++ b/packages/unistyles/plugin/src/stylesheet.ts
@@ -667,6 +667,8 @@ export function addDependencies(
 
     // add metadata about dependencies
     if (styleDependencies.length > 0) {
+        state.file.hasDynamicStyleSheet = true
+
         const uniqueDependencies = Array.from(new Set(styleDependencies))
 
         debugMessage(uniqueDependencies)

--- a/packages/unistyles/plugin/src/types.ts
+++ b/packages/unistyles/plugin/src/types.ts
@@ -6,8 +6,10 @@ interface UnistylesState {
     hasAnyUnistyle: boolean
     hasVariants: boolean
     hasUnistylesImport: boolean
+    hasDynamicStyleSheet: boolean
     addUnistylesRequire: boolean
     forceProcessing: boolean
+    isExcluded: boolean
     styleSheetLocalName: string
     replaceWithUnistyles: boolean
     reactNativeCommonJSName: string


### PR DESCRIPTION
## Summary

Related: https://github.com/jpudysz/react-native-unistyles/issues/1184

- **Static `StyleSheet.create` passthrough**: files inside `root` that only contain a static (no theme/rt/variants) `StyleSheet.create` and no React Native component imports are no longer processed by the plugin. The `StyleSheet` import is rewritten from `react-native-unistyles` → `react-native` so the Unistyles registry is never involved for those files.
- **`forceProcessing` is now lazy**: previously any file path-matching `root` immediately set `forceProcessing = true`, causing the plugin to rewrite imports even for pure style constants files. It now activates only when a qualifying React Native component import is actually detected.
- **`excludePaths` plugin option**: new array option that lets users explicitly opt entire path segments out of all plugin transforms (useful for design-token / constants folders).
- **`hasDynamicStyleSheet` flag**: set in `addDependencies` when `uni__dependencies` is injected; used to distinguish dynamic from static stylesheets in the exit handler.

## Test plan

- [x] `staticStyleSheet.spec.tsx` — static stylesheet rewrite to `react-native`, mixed static+RN component file stays on unistyles, dynamic (theme-using) stylesheet still injects `uni__dependencies`
- [x] `excludePaths.spec.tsx` — excluded paths are left completely untouched; non-excluded paths in same root are still processed normally
- [x] All existing suites (`stylesheet`, `dependencies`, `variants`, `imports`, `userImports`) still pass
- [x] TypeScript, lint, circular-dep checks all clean (52/52 tests passing)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `excludePaths` configuration option to the Babel plugin, enabling users to exclude specific file paths from processing while maintaining support for static StyleSheet and React Native imports.

* **Tests**
  * Added comprehensive test suites validating excludePaths functionality, StyleSheet import transformations, and plugin behavior across various scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->