### PR TITLE
fix(web): enhance server side cleanup

### DIFF
--- a/packages/unistyles/src/server/resetServerUnistyles.ts
+++ b/packages/unistyles/src/server/resetServerUnistyles.ts
@@ -7,4 +7,6 @@ export const resetServerUnistyles = () => {
     }
 
     unistyles.services.registry.reset()
+    unistyles.services.shadowRegistry.reset()
+    unistyles.services.listener.reset()
 }

--- a/packages/unistyles/src/web/listener.ts
+++ b/packages/unistyles/src/web/listener.ts
@@ -48,6 +48,12 @@ export class UnistylesListener {
         }
     }
 
+    reset = () => {
+        this.listeners.forEach((listeners) => listeners.clear())
+        this.stylesheetListeners.forEach((listeners) => listeners.clear())
+        this.changeListeners.clear()
+    }
+
     initListeners = () => {
         if (this.isInitialized) {
             return

--- a/packages/unistyles/src/web/registry.ts
+++ b/packages/unistyles/src/web/registry.ts
@@ -126,7 +126,9 @@ export class UnistylesRegistry {
     }
 
     reset = () => {
+        this.disposeListenersMap.forEach((dispose) => dispose())
         this.css.reset()
+        this.stylesheets.clear()
         this.stylesCache.clear()
         this.dependenciesMap.clear()
         this.disposeListenersMap.clear()

--- a/packages/unistyles/src/web/shadowRegistry.ts
+++ b/packages/unistyles/src/web/shadowRegistry.ts
@@ -121,5 +121,10 @@ export class UnistylesShadowRegistry {
         })
     }
 
+    reset = () => {
+        this.disposeMap.forEach((dispose) => dispose())
+        this.disposeMap.clear()
+    }
+
     flush = () => {}
 }


### PR DESCRIPTION
## Summary

We noticed memory steadily increasing in our production Next.js app under traffic. The leak seems to come from server-side Unistyles cleanup not fully releasing everything it registered during a request. Some listeners were being left behind and kept accumulating across requests until server process restarts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Registry reset now disposes stylesheet listener subscriptions and fully clears stylesheet state for more reliable cleanup.
  * Server-side reset extended to cover additional server registries, preventing stale state on server runs.
  * Listener systems gained reset behavior to remove stored listeners and disposer references, avoiding lingering subscriptions.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jpudysz/react-native-unistyles/pull/1189)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->