### PR TITLE
fix: drain shadow-tree updates before committing

### DIFF
--- a/packages/unistyles/cxx/core/UnistylesRegistry.cpp
+++ b/packages/unistyles/cxx/core/UnistylesRegistry.cpp
@@ -122,12 +122,17 @@ void core::UnistylesRegistry::suspendShadowNode(const ShadowNodeFamily* shadowNo
     this->trafficController.withLock([this, shadowNodeFamily](){
         if (this->_shadowRegistry.contains(shadowNodeFamily)) {
             this->_suspendedFamilies.insert(shadowNodeFamily);
+            this->trafficController.removeShadowNode(shadowNodeFamily);
         }
     });
 }
 
 bool core::UnistylesRegistry::isSuspended(const ShadowNodeFamily* family) const noexcept {
     return _suspendedFamilies.count(family) > 0;
+}
+
+bool core::UnistylesRegistry::isActiveUnistylesFamily(const ShadowNodeFamily* family) const noexcept {
+    return _shadowRegistry.count(family) > 0 && _suspendedFamilies.count(family) == 0;
 }
 
 std::shared_ptr<core::StyleSheet> core::UnistylesRegistry::addStyleSheet(jsi::Runtime& rt, core::StyleSheetType type, jsi::Object&& rawValue) {
@@ -145,6 +150,10 @@ core::DependencyMap core::UnistylesRegistry::buildDependencyMap(std::vector<Unis
     std::unordered_set<UnistyleDependency> uniqueDependencies(deps.begin(), deps.end());
 
     for (const auto& [family, unistyles] : this->_shadowRegistry) {
+        if (this->_suspendedFamilies.count(family) > 0) {
+            continue;
+        }
+
         bool hasAnyOfDependencies = false;
 
         // Check if any dependency matches

--- a/packages/unistyles/cxx/core/UnistylesRegistry.h
+++ b/packages/unistyles/cxx/core/UnistylesRegistry.h
@@ -44,6 +44,8 @@ struct UnistylesRegistry: public StyleSheetRegistry {
     void unlinkShadowNodeWithUnistyles(const ShadowNodeFamily*);
     void suspendShadowNode(const ShadowNodeFamily*);
     bool isSuspended(const ShadowNodeFamily*) const noexcept;
+    // Caller must hold trafficController's lock when link/unlink/suspend may race.
+    bool isActiveUnistylesFamily(const ShadowNodeFamily*) const noexcept;
     std::shared_ptr<core::StyleSheet> addStyleSheet(jsi::Runtime& rt, core::StyleSheetType type, jsi::Object&& rawValue);
     DependencyMap buildDependencyMap(std::vector<UnistyleDependency>& deps);
     void shadowLeafUpdateFromUnistyle(jsi::Runtime& rt, Unistyle::Shared unistyle, jsi::Value& maybePressableId);

--- a/packages/unistyles/cxx/shadowTree/ShadowTrafficController.h
+++ b/packages/unistyles/cxx/shadowTree/ShadowTrafficController.h
@@ -20,9 +20,13 @@ struct ShadowTrafficController {
         this->_canCommit = true;
     }
 
-    inline shadow::ShadowLeafUpdates& getUpdates() {
+    inline shadow::ShadowLeafUpdates takeUpdates() {
         // call it only within withLock!
-        return _unistylesUpdates;
+        auto updates = std::move(_unistylesUpdates);
+        _unistylesUpdates = {};
+        _canCommit = false;
+
+        return updates;
     }
 
     inline void setUpdates(shadow::ShadowLeafUpdates& newUpdates) {

--- a/packages/unistyles/cxx/shadowTree/ShadowTreeManager.cpp
+++ b/packages/unistyles/cxx/shadowTree/ShadowTreeManager.cpp
@@ -10,7 +10,19 @@ void shadow::ShadowTreeManager::updateShadowTree(jsi::Runtime& rt) {
     auto& registry = core::UnistylesRegistry::get();
 
     registry.trafficController.withLock([&](){
-        auto updates = registry.trafficController.getUpdates();
+        auto updates = registry.trafficController.takeUpdates();
+
+        if (updates.empty()) {
+            return;
+        }
+
+        for (auto it = updates.begin(); it != updates.end();) {
+            if (!registry.isActiveUnistylesFamily(it->first)) {
+                it = updates.erase(it);
+            } else {
+                ++it;
+            }
+        }
 
         if (updates.empty()) {
             return;


### PR DESCRIPTION
Fixes #1179.

The reported crash is deterministic native heap corruption in `ShadowTreeManager::updateShadowTree` when appearance/theme changes trigger Unistyles dependency updates, especially the `setAdaptiveThemes(false)` followed by `setTheme(...)` path from the issue repro. The crash shows up as libmalloc aborts or bad-pointer `EXC_BAD_ACCESS` on iOS, but the unsafe state lives in the shared C++ shadow-tree update path rather than an iOS-only layer.

A downstream beta app confirmed the production mitigation in rollercoaster-dev/monorepo#1060: removing rapid/back-to-back `UnistylesRuntime.setTheme()` calls stopped the crash in both iOS and Android beta builds. That mitigation reduces the trigger surface, but it does not fix the underlying library behavior: pending shadow updates could still be replayed later if they outlive the active shadow-node family they reference.

This PR makes shadow updates single-use. `ShadowTrafficController` now drains pending updates with `takeUpdates()` before a commit instead of exposing cumulative updates indefinitely. Suspended/unlinked families are removed from pending traffic, suspended families are skipped while building dependency maps, and `ShadowTreeManager::updateShadowTree()` filters inactive families before touching `nativeProps_DEPRECATED` or walking ancestors.

The goal is to narrow the lifetime of raw `ShadowNodeFamily*` keys so stale entries are not replayed after suspension/unlink and cannot be dereferenced by `findAffectedNodes()` or native-props mutation during a later dependency change.

Validated in private beta builds on iOS and Android: rapid theme/appearance changes no longer reproduce the original shadow-tree crash.