### PR TITLE
feat: support all key casings in variants

### DIFF
--- a/packages/unistyles/plugin/__tests__/variants.spec.tsx
+++ b/packages/unistyles/plugin/__tests__/variants.spec.tsx
@@ -216,5 +216,141 @@ pluginTester({
                 const styles = StyleSheet.create({})
             `,
         },
+        {
+            title: 'Should detect variants on string-literal keyed styles (#1188)',
+            code: `
+                import { View, Text } from 'react-native'
+                import { StyleSheet } from 'react-native-unistyles'
+
+                export const Example = () => {
+                    styles.useVariants({
+                        size: 'small'
+                    })
+
+                    return (
+                        <View style={styles['headline-large']}>
+                            <Text>Hello world</Text>
+                        </View>
+                    )
+                }
+
+                const styles = StyleSheet.create((theme, rt) => ({
+                    'headline-large': {
+                        backgroundColor: theme.colors.background,
+                        variants: {
+                            size: {
+                                small: {
+                                    width: 100
+                                },
+                                large: {
+                                    width: 300
+                                }
+                            }
+                        }
+                    }
+                }))
+            `,
+            output: `
+                import { Text } from 'react-native-unistyles/components/native/Text'
+                import { View } from 'react-native-unistyles/components/native/View'
+
+                import { StyleSheet } from 'react-native-unistyles'
+
+                export const Example = () => {
+                    const _styles = styles
+                    {
+                        const styles = _styles.useVariants({
+                            size: 'small'
+                        })
+
+                        return (
+                            <View style={styles['headline-large']}>
+                                <Text>Hello world</Text>
+                            </View>
+                        )
+                    }
+                }
+
+                const styles = StyleSheet.create((theme, rt) => ({
+                    'headline-large': {
+                        backgroundColor: theme.colors.background,
+                        variants: {
+                            size: {
+                                small: {
+                                    width: 100
+                                },
+                                large: {
+                                    width: 300
+                                }
+                            }
+                        },
+                        uni__dependencies: [0, 4]
+                    }
+                }))
+            `,
+        },
+        {
+            title: 'Should detect variants on string-literal keyed styles in object form (#1188)',
+            code: `
+                import { View, Text } from 'react-native'
+                import { StyleSheet } from 'react-native-unistyles'
+
+                export const Example = () => {
+                    styles.useVariants({
+                        size: 'small'
+                    })
+
+                    return (
+                        <View style={styles['headline-large']}>
+                            <Text>Hello world</Text>
+                        </View>
+                    )
+                }
+
+                const styles = StyleSheet.create({
+                    'headline-large': {
+                        variants: {
+                            size: {
+                                small: { width: 100 },
+                                large: { width: 300 }
+                            }
+                        }
+                    }
+                })
+            `,
+            output: `
+                import { Text } from 'react-native-unistyles/components/native/Text'
+                import { View } from 'react-native-unistyles/components/native/View'
+
+                import { StyleSheet } from 'react-native-unistyles'
+
+                export const Example = () => {
+                    const _styles = styles
+                    {
+                        const styles = _styles.useVariants({
+                            size: 'small'
+                        })
+
+                        return (
+                            <View style={styles['headline-large']}>
+                                <Text>Hello world</Text>
+                            </View>
+                        )
+                    }
+                }
+
+                const styles = StyleSheet.create({
+                    'headline-large': {
+                        variants: {
+                            size: {
+                                small: { width: 100 },
+                                large: { width: 300 }
+                            }
+                        },
+                        uni__dependencies: [4]
+                    }
+                })
+            `,
+        },
     ],
 })

--- a/packages/unistyles/plugin/index.js
+++ b/packages/unistyles/plugin/index.js
@@ -219,6 +219,18 @@ var UnistyleDependency = {
   Ime: 14,
   Rtl: 15
 };
+function getStyleKeyName(key) {
+  if (!key) {
+    return null;
+  }
+  if (t4.isIdentifier(key)) {
+    return key.name;
+  }
+  if (t4.isStringLiteral(key) || t4.isNumericLiteral(key) || t4.isBooleanLiteral(key)) {
+    return String(key.value);
+  }
+  return null;
+}
 function getProperty(property) {
   if (!property) {
     return void 0;
@@ -389,28 +401,30 @@ function getStylesDependenciesFromObject(path2) {
   const stylesheet = path2.node.arguments[0];
   if (t4.isObjectExpression(stylesheet)) {
     stylesheet?.properties.forEach((property) => {
-      if (!t4.isObjectProperty(property) || !t4.isIdentifier(property.key)) {
+      if (!t4.isObjectProperty(property)) {
         return;
       }
-      if (t4.isObjectProperty(property)) {
-        if (t4.isObjectExpression(property.value)) {
-          property.value.properties.forEach((innerProp) => {
-            if (t4.isObjectProperty(innerProp) && t4.isIdentifier(innerProp.key) && t4.isIdentifier(property.key) && innerProp.key.name === "variants") {
-              detectedStylesWithVariants.add({
-                label: "variants",
-                key: property.key.name
-              });
-            }
-          });
-        }
+      const styleKey = getStyleKeyName(property.key);
+      if (!styleKey) {
+        return;
+      }
+      if (t4.isObjectExpression(property.value)) {
+        property.value.properties.forEach((innerProp) => {
+          if (t4.isObjectProperty(innerProp) && t4.isIdentifier(innerProp.key) && innerProp.key.name === "variants") {
+            detectedStylesWithVariants.add({
+              label: "variants",
+              key: styleKey
+            });
+          }
+        });
       }
       if (t4.isArrowFunctionExpression(property.value)) {
         if (t4.isObjectExpression(property.value.body)) {
           property.value.body.properties.forEach((innerProp) => {
-            if (t4.isObjectProperty(innerProp) && t4.isIdentifier(innerProp.key) && t4.isIdentifier(property.key) && innerProp.key.name === "variants") {
+            if (t4.isObjectProperty(innerProp) && t4.isIdentifier(innerProp.key) && innerProp.key.name === "variants") {
               detectedStylesWithVariants.add({
                 label: "variants",
-                key: property.key.name
+                key: styleKey
               });
             }
           });
@@ -493,10 +507,10 @@ function getStylesDependenciesFromFunction(funcPath) {
     if (Array.isArray(stylePath)) {
       return;
     }
-    if (!stylePath.isIdentifier()) {
+    const styleKey = getStyleKeyName(stylePath.node);
+    if (!styleKey) {
       return;
     }
-    const styleKey = stylePath.node.name;
     const valuePath = propPath.get("value");
     if (Array.isArray(valuePath)) {
       return;
@@ -901,13 +915,12 @@ function index_default() {
           if (detectedDependencies) {
             if (t6.isObjectExpression(arg)) {
               arg.properties.forEach((property) => {
-                if (t6.isObjectProperty(property) && t6.isIdentifier(property.key) && Object.prototype.hasOwnProperty.call(detectedDependencies, property.key.name)) {
-                  addDependencies(
-                    state,
-                    property.key.name,
-                    property,
-                    detectedDependencies[property.key.name] ?? []
-                  );
+                if (!t6.isObjectProperty(property)) {
+                  return;
+                }
+                const styleKey = getStyleKeyName(property.key);
+                if (styleKey && Object.prototype.hasOwnProperty.call(detectedDependencies, styleKey)) {
+                  addDependencies(state, styleKey, property, detectedDependencies[styleKey] ?? []);
                 }
               });
             }
@@ -920,13 +933,12 @@ function index_default() {
             const body = t6.isBlockStatement(arg.body) ? arg.body.body.find((statement) => t6.isReturnStatement(statement))?.argument : arg.body;
             if (t6.isObjectExpression(body)) {
               body.properties.forEach((property) => {
-                if (t6.isObjectProperty(property) && t6.isIdentifier(property.key) && Object.prototype.hasOwnProperty.call(detectedDependencies, property.key.name)) {
-                  addDependencies(
-                    state,
-                    property.key.name,
-                    property,
-                    detectedDependencies[property.key.name] ?? []
-                  );
+                if (!t6.isObjectProperty(property)) {
+                  return;
+                }
+                const styleKey = getStyleKeyName(property.key);
+                if (styleKey && Object.prototype.hasOwnProperty.call(detectedDependencies, styleKey)) {
+                  addDependencies(state, styleKey, property, detectedDependencies[styleKey] ?? []);
                 }
               });
             }

--- a/packages/unistyles/plugin/src/index.ts
+++ b/packages/unistyles/plugin/src/index.ts
@@ -17,6 +17,7 @@ import { toPlatformPath } from './paths'
 import { hasStringRef } from './ref'
 import {
     addDependencies,
+    getStyleKeyName,
     getStylesDependenciesFromFunction,
     getStylesDependenciesFromObject,
     isKindOfStyleSheet,
@@ -254,17 +255,14 @@ export default function (): PluginObj<UnistylesPluginPass> {
                     if (detectedDependencies) {
                         if (t.isObjectExpression(arg)) {
                             arg.properties.forEach((property) => {
-                                if (
-                                    t.isObjectProperty(property) &&
-                                    t.isIdentifier(property.key) &&
-                                    Object.prototype.hasOwnProperty.call(detectedDependencies, property.key.name)
-                                ) {
-                                    addDependencies(
-                                        state,
-                                        property.key.name,
-                                        property,
-                                        detectedDependencies[property.key.name] ?? [],
-                                    )
+                                if (!t.isObjectProperty(property)) {
+                                    return
+                                }
+
+                                const styleKey = getStyleKeyName(property.key)
+
+                                if (styleKey && Object.prototype.hasOwnProperty.call(detectedDependencies, styleKey)) {
+                                    addDependencies(state, styleKey, property, detectedDependencies[styleKey] ?? [])
                                 }
                             })
                         }
@@ -286,17 +284,14 @@ export default function (): PluginObj<UnistylesPluginPass> {
                         // Ensure the function body returns an object
                         if (t.isObjectExpression(body)) {
                             body.properties.forEach((property) => {
-                                if (
-                                    t.isObjectProperty(property) &&
-                                    t.isIdentifier(property.key) &&
-                                    Object.prototype.hasOwnProperty.call(detectedDependencies, property.key.name)
-                                ) {
-                                    addDependencies(
-                                        state,
-                                        property.key.name,
-                                        property,
-                                        detectedDependencies[property.key.name] ?? [],
-                                    )
+                                if (!t.isObjectProperty(property)) {
+                                    return
+                                }
+
+                                const styleKey = getStyleKeyName(property.key)
+
+                                if (styleKey && Object.prototype.hasOwnProperty.call(detectedDependencies, styleKey)) {
+                                    addDependencies(state, styleKey, property, detectedDependencies[styleKey] ?? [])
                                 }
                             })
                         }

--- a/packages/unistyles/plugin/src/stylesheet.ts
+++ b/packages/unistyles/plugin/src/stylesheet.ts
@@ -32,6 +32,22 @@ const UnistyleDependency = {
     Rtl: 15,
 }
 
+export function getStyleKeyName(key: t.Node | null | undefined): string | null {
+    if (!key) {
+        return null
+    }
+
+    if (t.isIdentifier(key)) {
+        return key.name
+    }
+
+    if (t.isStringLiteral(key) || t.isNumericLiteral(key) || t.isBooleanLiteral(key)) {
+        return String(key.value)
+    }
+
+    return null
+}
+
 function getProperty(property: t.ObjectProperty | t.RestElement): Props | undefined {
     if (!property) {
         return undefined
@@ -269,26 +285,29 @@ export function getStylesDependenciesFromObject(path: NodePath<t.CallExpression>
 
     if (t.isObjectExpression(stylesheet)) {
         stylesheet?.properties.forEach((property) => {
-            if (!t.isObjectProperty(property) || !t.isIdentifier(property.key)) {
+            if (!t.isObjectProperty(property)) {
                 return
             }
 
-            if (t.isObjectProperty(property)) {
-                if (t.isObjectExpression(property.value)) {
-                    property.value.properties.forEach((innerProp) => {
-                        if (
-                            t.isObjectProperty(innerProp) &&
-                            t.isIdentifier(innerProp.key) &&
-                            t.isIdentifier(property.key) &&
-                            innerProp.key.name === 'variants'
-                        ) {
-                            detectedStylesWithVariants.add({
-                                label: 'variants',
-                                key: property.key.name,
-                            })
-                        }
-                    })
-                }
+            const styleKey = getStyleKeyName(property.key)
+
+            if (!styleKey) {
+                return
+            }
+
+            if (t.isObjectExpression(property.value)) {
+                property.value.properties.forEach((innerProp) => {
+                    if (
+                        t.isObjectProperty(innerProp) &&
+                        t.isIdentifier(innerProp.key) &&
+                        innerProp.key.name === 'variants'
+                    ) {
+                        detectedStylesWithVariants.add({
+                            label: 'variants',
+                            key: styleKey,
+                        })
+                    }
+                })
             }
 
             if (t.isArrowFunctionExpression(property.value)) {
@@ -297,12 +316,11 @@ export function getStylesDependenciesFromObject(path: NodePath<t.CallExpression>
                         if (
                             t.isObjectProperty(innerProp) &&
                             t.isIdentifier(innerProp.key) &&
-                            t.isIdentifier(property.key) &&
                             innerProp.key.name === 'variants'
                         ) {
                             detectedStylesWithVariants.add({
                                 label: 'variants',
-                                key: property.key.name,
+                                key: styleKey,
                             })
                         }
                     })
@@ -422,11 +440,12 @@ export function getStylesDependenciesFromFunction(funcPath: NodePath<t.Node> | A
             return
         }
 
-        if (!stylePath.isIdentifier()) {
+        const styleKey = getStyleKeyName(stylePath.node)
+
+        if (!styleKey) {
             return
         }
 
-        const styleKey = stylePath.node.name
         const valuePath = propPath.get('value')
 
         if (Array.isArray(valuePath)) {


### PR DESCRIPTION
## Summary

Fix #1188 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed variant detection for string-literal style keys in StyleSheet.create (e.g., `styles['headline-large']`). Variant wrapping now correctly applies to both identifier and literal-key styles.

* **Tests**
  * Added test coverage for variant detection with string-literal style keys in stylesheet declarations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jpudysz/react-native-unistyles/pull/1194?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->