### PR TITLE
fix: remove invalid system bar root exports

### DIFF
--- a/packages/unistyles/src/index.ts
+++ b/packages/unistyles/src/index.ts
@@ -6,7 +6,7 @@ if (majorReactVersions === undefined || majorReactVersions < 19) {
     throw new Error('Unistyles 🦄: To enable full Fabric power you need to use React 19.0.0 or higher')
 }
 
-export { StyleSheet, UnistylesRuntime, StatusBar, NavigationBar } from './specs'
+export { StyleSheet, UnistylesRuntime } from './specs'
 export { UnistyleDependency } from './specs'
 export { mq } from './mq'
 export type { UnistylesThemes, UnistylesBreakpoints } from './global'

--- a/packages/unistyles/src/web/index.ts
+++ b/packages/unistyles/src/web/index.ts
@@ -33,5 +33,3 @@ export const StyleSheet = {
 export const UnistylesRuntime = unistyles.services.runtime as unknown as typeof NativeUnistylesRuntime
 export const UnistylesShadowRegistry = unistyles.services
     .shadowRegistry as unknown as typeof NativeUnistylesShadowRegistry
-
-export * from './mock'

--- a/skills/react-native-unistyles-v3/references/api-reference.md
+++ b/skills/react-native-unistyles-v3/references/api-reference.md
@@ -157,8 +157,10 @@ UnistylesRuntime.setImmersiveMode(true)
 
 ## StatusBar
 
+Accessed via `UnistylesRuntime.statusBar`.
+
 ```tsx
-import { StatusBar } from 'react-native-unistyles'
+UnistylesRuntime.statusBar
 ```
 
 | Property/Method | Type | Description |
@@ -168,14 +170,14 @@ import { StatusBar } from 'react-native-unistyles'
 | `setHidden(hidden, animation?)` | `(boolean, 'none' \| 'fade' \| 'slide') => void` | Show/hide status bar |
 | `setStyle(style, animated?)` | `('default' \| 'light' \| 'dark', boolean?) => void` | Set status bar style |
 
-Also accessible via `UnistylesRuntime.statusBar`.
-
 ---
 
 ## NavigationBar
 
+Accessed via `UnistylesRuntime.navigationBar`.
+
 ```tsx
-import { NavigationBar } from 'react-native-unistyles'
+UnistylesRuntime.navigationBar
 ```
 
 | Property/Method | Type | Description |
@@ -183,8 +185,6 @@ import { NavigationBar } from 'react-native-unistyles'
 | `width` | `number` | Navigation bar width |
 | `height` | `number` | Navigation bar height |
 | `setHidden(hidden)` | `(boolean) => void` | Show/hide navigation bar (Android) |
-
-Also accessible via `UnistylesRuntime.navigationBar`.
 
 ---
 


### PR DESCRIPTION
## Summary

Remove `StatusBar` and `NavigationBar` from the root `react-native-unistyles` exports. The native `./specs` entry does not export these names, so the root entrypoint currently re-exports bindings that do not exist on native.

This can be missed in Metro because it may not eagerly validate this re-export when consumers do not directly import those names. Strict ESM tooling does validate the module graph and fails during build, but that is only surfacing the package export mismatch rather than causing it.

Keeping the root export list aligned with the native specs prevents consumers from importing `StatusBar` / `NavigationBar` from `react-native-unistyles` and getting an invalid native binding.

Validation:
- `node_modules/typescript/bin/tsc --noEmit -p packages/unistyles/tsconfig.json`
- `bun run --cwd packages/unistyles lint`
- `bun run --cwd packages/unistyles check:ci`
- `bun run --cwd packages/unistyles test`

Note: the package `tsc` script was not used directly because this local Bun workspace install does not create `packages/unistyles/node_modules/typescript/bin/tsc`; the same TypeScript version from the root workspace was used instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Adjusted public exports: `StatusBar` and `NavigationBar` are no longer top-level exports; use `UnistylesRuntime` sub-objects instead.
  * Updated the web build exports and removed the broad mock export surface.
* **Documentation**
  * Refreshed the `react-native-unistyles` API reference to show `UnistylesRuntime.statusBar` and `UnistylesRuntime.navigationBar` usage, removing redundant guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->