### PR TITLE
fix(web): detect Reanimated 3 useAnimatedStyle in checkForAnimated

### DIFF
--- a/packages/unistyles/src/__tests__/checkForAnimated.spec.ts
+++ b/packages/unistyles/src/__tests__/checkForAnimated.spec.ts
@@ -1,0 +1,73 @@
+import { Animated } from 'react-native'
+
+import { assignSecrets, checkForAnimated } from '../web/utils/unistyle'
+
+describe('checkForAnimated', () => {
+    it('returns false for primitives', () => {
+        expect(checkForAnimated(undefined)).toBe(false)
+        expect(checkForAnimated(null)).toBe(false)
+        expect(checkForAnimated(0)).toBe(false)
+        expect(checkForAnimated('flex')).toBe(false)
+        expect(checkForAnimated(true)).toBe(false)
+    })
+
+    it('returns false for plain styles', () => {
+        expect(checkForAnimated({ flex: 1, backgroundColor: 'red' })).toBe(false)
+    })
+
+    it('returns true for legacy `Animated.Node` instances (Animated API)', () => {
+        const animatedValue = new Animated.Value(0)
+
+        // The interpolation produces an `AnimatedInterpolation` (a subclass of
+        // `Animated.Node`), which is the historical signal `checkForAnimated`
+        // was originally written to detect.
+        const interpolated = animatedValue.interpolate({
+            inputRange: [0, 1],
+            outputRange: [0, 1],
+        })
+
+        expect(checkForAnimated({ opacity: interpolated })).toBe(true)
+    })
+
+    it('returns true for Reanimated 3 `useAnimatedStyle` return values', () => {
+        // `useAnimatedStyle()` returns a plain object of this shape on web. It
+        // is NOT an instance of `Animated.Node`, and none of its nested values
+        // are either, so the legacy `instanceof` and recursive checks both miss
+        // it. Detect the shape directly.
+        const reanimatedHandle = {
+            viewDescriptors: { shareableViewDescriptors: {}, add: jest.fn(), remove: jest.fn(), has: jest.fn() },
+            initial: { value: { opacity: 0 }, updater: jest.fn() },
+            styleUpdaterContainer: { current: jest.fn() },
+        }
+
+        expect(checkForAnimated(reanimatedHandle)).toBe(true)
+    })
+
+    it('does not falsely flag plain objects that share one of the Reanimated keys', () => {
+        // A regular style object that happens to contain a `viewDescriptors`
+        // key alone (or just one of the three) is not a Reanimated handle.
+        // Require all three before treating the value as animated.
+        expect(checkForAnimated({ viewDescriptors: {} })).toBe(false)
+        expect(checkForAnimated({ initial: {} })).toBe(false)
+        expect(checkForAnimated({ styleUpdaterContainer: {} })).toBe(false)
+        expect(checkForAnimated({ viewDescriptors: {}, initial: {} })).toBe(false)
+    })
+
+    it('recurses into arrays and nested objects to find an animated descriptor', () => {
+        const animatedValue = new Animated.Value(0)
+        const interpolated = animatedValue.interpolate({ inputRange: [0, 1], outputRange: [0, 1] })
+
+        expect(checkForAnimated([{ opacity: interpolated }])).toBe(true)
+        expect(checkForAnimated({ transform: [{ translateX: interpolated }] })).toBe(true)
+    })
+
+    it('treats values with empty unistyles secrets as animated (existing behavior)', () => {
+        // `assignSecrets` adds a non-enumerable `unistyles_*` bag. When the bag
+        // exists but is empty, that's the marker for an already-resolved
+        // animated style; `getClassName` relies on this to short-circuit.
+        const value: Record<string, unknown> = { opacity: 1 }
+        assignSecrets(value, {} as never)
+
+        expect(checkForAnimated(value)).toBe(true)
+    })
+})

--- a/packages/unistyles/src/web/utils/unistyle.ts
+++ b/packages/unistyles/src/web/utils/unistyle.ts
@@ -141,6 +141,16 @@ export const checkForAnimated = (value: any): boolean => {
         const objectValues = Object.values(value)
         const secrets = extractSecrets(value)
 
+        // Reanimated 3's `useAnimatedStyle` return value is a plain object
+        // `{ viewDescriptors, initial, styleUpdaterContainer }` and is NOT an
+        // instance of `Animated.Node`, so the legacy check below misses it
+        // and the animated style gets routed through `getClassName` as a
+        // regular style. Detect the shape explicitly so the descriptor reaches
+        // Reanimated's `AnimatedComponent` and inline-style updates work on web.
+        if ('viewDescriptors' in value && 'initial' in value && 'styleUpdaterContainer' in value) {
+            return true
+        }
+
         // @ts-expect-error React Native Web exports Animated.AnimatedNode as Animated.Node
         // prettier-ignore
         return value instanceof Animated.Node || objectValues.length > 0 && objectValues.some(checkForAnimated) || secrets && Object.keys(secrets).length === 0


### PR DESCRIPTION
## Summary

Fixes #1199.

`checkForAnimated` (in `packages/unistyles/src/web/utils/unistyle.ts`) only recognises legacy `Animated.Node` instances. It misses Reanimated 3's `useAnimatedStyle` return value, which is a plain object `{ viewDescriptors, initial, styleUpdaterContainer }` — none of those nested values are `Animated.Node` instances either, so the recursive `objectValues.some(checkForAnimated)` fallback also misses it.

The animated descriptor then flows through `getClassName` as a regular style, gets handed to `addStyles`, which has nothing meaningful to do with `viewDescriptors`/`initial`/`styleUpdaterContainer`, and the descriptor never reaches Reanimated's `AnimatedComponent`. Symptom: any component using `useAnimatedStyle` inside a v3-wrapped element renders with the static initial values and never animates on web.

## Fix

Detect the Reanimated 3 handle by shape:

```ts
if ('viewDescriptors' in value && 'initial' in value && 'styleUpdaterContainer' in value) {
    return true
}
```

All three keys are required so we don't false-positive on a plain style that happens to contain `viewDescriptors` (or any of the others) by itself. The check sits before the existing `Animated.Node` / recursive / empty-secrets logic, so the legacy paths still apply unchanged for everything else.

## Reproduction

```tsx
import { useEffect } from 'react'
import Animated, { useAnimatedStyle, useSharedValue, withRepeat, withTiming } from 'react-native-reanimated'
import { StyleSheet, createUnistylesElement } from 'react-native-unistyles'

const AnimatedView = createUnistylesElement(Animated.View)

export function PulsingBox() {
    const opacity = useSharedValue(0.2)
    useEffect(() => {
        opacity.value = withRepeat(withTiming(0.8, { duration: 1000 }), -1, true)
    }, [opacity])
    const animatedStyle = useAnimatedStyle(() => ({ opacity: opacity.value }))

    // On web before this fix: opacity stays at 1, no inline style is written.
    // After this fix: pulses 0.2 ↔ 0.8 as expected.
    return <AnimatedView style={[styles.box, animatedStyle]} />
}

const styles = StyleSheet.create((theme) => ({
    box: { width: 64, height: 64, backgroundColor: theme.colors.containerHighest },
}))
```

## Test plan

Adds `packages/unistyles/src/__tests__/checkForAnimated.spec.ts` covering:

- Primitives (undefined / null / number / string / boolean) → `false`
- Plain styles → `false`
- Legacy `Animated.Node` from RN's `Animated.Value().interpolate(...)` → `true`
- Reanimated 3 handle (`{ viewDescriptors, initial, styleUpdaterContainer }`) → `true`
- Single-property false-positive cases (`{ viewDescriptors }` alone, etc.) → `false`
- Recursion through arrays and nested objects → `true`
- Existing empty-`unistyles_*`-secrets short-circuit → `true`

## Notes

A more durable check might import a stable Reanimated symbol (e.g. a private brand on `useAnimatedStyle` results) if Reanimated ever exposes one. The property-name check is fragile across Reanimated major versions, but works today and matches the shape `useAnimatedStyle` has had since Reanimated 3.0.

This change has been running locally as a yarn patch on `react-native-unistyles@3.2.5` for several weeks, fixing animations on Tooltip, ExpandableListItem, and progress-stepper components inside our v3-wrapped design system on the web.

## Environment

- `react-native-unistyles@3.2.5`
- `react-native-reanimated@4.3.1`
- React Native Web via Vite + Storybook (also via Expo Router / Metro on web)

## Related code

- `packages/unistyles/src/web/utils/unistyle.ts` — `checkForAnimated`
- `packages/unistyles/src/core/getClassname.ts` — splits regular vs animated via `checkForAnimated`
- `packages/unistyles/src/core/createUnistylesElement.ts` — wrapper applied to RN components

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for animation detection functionality, validating behavior across primitives, style objects, React Native Animated values, and Reanimated 3 animated styles.

* **Bug Fixes**
  * Fixed animation detection for Reanimated 3 `useAnimatedStyle` results on web, ensuring proper routing through animation handling pathways.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->