### PR TITLE
fix(specs): point absoluteFillObject at NativeStyleSheet.absoluteFillObject

### DIFF
--- a/packages/unistyles/src/specs/StyleSheet/index.ts
+++ b/packages/unistyles/src/specs/StyleSheet/index.ts
@@ -35,7 +35,7 @@ export type UnistylesConfig = {
 }
 
 export interface UnistylesStyleSheet extends UnistylesStyleSheetSpec {
-    absoluteFillObject: typeof NativeStyleSheetType.absoluteFill
+    absoluteFillObject: typeof NativeStyleSheetType.absoluteFillObject
     absoluteFill: typeof NativeStyleSheetType.absoluteFill
     compose: typeof NativeStyleSheetType.compose
     flatten: typeof NativeStyleSheetType.flatten
@@ -52,7 +52,7 @@ export interface UnistylesStyleSheet extends UnistylesStyleSheetSpec {
 
 const HybridUnistylesStyleSheet = NitroModules.createHybridObject<UnistylesStyleSheet>('UnistylesStyleSheet')
 
-HybridUnistylesStyleSheet.absoluteFillObject = NativeStyleSheet.absoluteFill
+HybridUnistylesStyleSheet.absoluteFillObject = NativeStyleSheet.absoluteFillObject
 HybridUnistylesStyleSheet.absoluteFill = NativeStyleSheet.absoluteFill
 HybridUnistylesStyleSheet.flatten = NativeStyleSheet.flatten
 HybridUnistylesStyleSheet.compose = NativeStyleSheet.compose


### PR DESCRIPTION
## Summary

Fixes #1200.

`packages/unistyles/src/specs/StyleSheet/index.ts` aliases `StyleSheet.absoluteFillObject` to `NativeStyleSheet.absoluteFill` — a registered style ID (a number on web, an internal identifier on native), not the `{ position: 'absolute', top: 0, left: 0, right: 0, bottom: 0 }` descriptor that React Native's own `StyleSheet.absoluteFillObject` exposes.

The mismatch shows up in user code:

\`\`\`ts
import { StyleSheet } from 'react-native-unistyles'

// TS2698: Spread types may only be created from object types.
const style = {
    ...StyleSheet.absoluteFillObject,
    backgroundColor: 'red',
}

// Runtime (web): \`absoluteFillObject\` is a number, not a descriptor.
console.log(StyleSheet.absoluteFillObject) // -> e.g. 1
\`\`\`

By contrast, in upstream React Native:

\`\`\`ts
import { StyleSheet } from 'react-native'
console.log(StyleSheet.absoluteFillObject)
// { position: 'absolute', top: 0, left: 0, right: 0, bottom: 0 }
\`\`\`

The web entry (\`packages/unistyles/src/web/index.ts\`) and the mocks (\`packages/unistyles/src/mocks.ts\`) already expose \`absoluteFillObject\` as the descriptor, so the discrepancy is specific to the native specs file.

## Fix

Two surgical changes in \`packages/unistyles/src/specs/StyleSheet/index.ts\`:

\`\`\`diff
 export interface UnistylesStyleSheet extends UnistylesStyleSheetSpec {
-    absoluteFillObject: typeof NativeStyleSheetType.absoluteFill
+    absoluteFillObject: typeof NativeStyleSheetType.absoluteFillObject
     absoluteFill: typeof NativeStyleSheetType.absoluteFill
\`\`\`

\`\`\`diff
-HybridUnistylesStyleSheet.absoluteFillObject = NativeStyleSheet.absoluteFill
+HybridUnistylesStyleSheet.absoluteFillObject = NativeStyleSheet.absoluteFillObject
 HybridUnistylesStyleSheet.absoluteFill = NativeStyleSheet.absoluteFill
\`\`\`

\`absoluteFill\` (the registered ID) is intentionally left untouched — that one matches RN's contract and any code that depends on the numeric ID for native perf would break if it changed shape.

## Test plan

- Type check: spreading \`StyleSheet.absoluteFillObject\` no longer triggers TS2698.
- Runtime (web): \`StyleSheet.absoluteFillObject\` is the descriptor object, matching \`react-native\`'s \`StyleSheet.absoluteFillObject\`.
- Existing web entry and mocks were already exposing the descriptor, so no behavioral change there. The web \`StyleSheet\` runtime in \`packages/unistyles/src/web/index.ts\` and the mock in \`packages/unistyles/src/mocks.ts\` already match this shape.

I'd have added a runtime unit test, but the spec file is initialised via \`NitroModules.createHybridObject\` and isn't easy to exercise inside the existing Jest setup. The mocks (which the existing \`mocks.spec.ts\` covers) and the web entry already do the right thing — this PR just brings the native specs file into agreement with them.

## Related code

- \`packages/unistyles/src/specs/StyleSheet/index.ts\` — the file changed
- \`packages/unistyles/src/web/index.ts\` — already correct, kept as reference
- \`packages/unistyles/src/mocks.ts\` — already correct, kept as reference