### PR TITLE
fix(web): avoid retaining HTMLElement refs in stylesCounter

### DIFF
--- a/packages/unistyles/src/__tests__/web-registry.spec.ts
+++ b/packages/unistyles/src/__tests__/web-registry.spec.ts
@@ -77,4 +77,74 @@ describe('UnistylesRegistry counter', () => {
         expect(removed).toBe(false)
         expect(cssRemoveSpy).not.toHaveBeenCalled()
     })
+
+    it('tracks counters independently when one element carries multiple hashes', async () => {
+        const { registry, cssRemoveSpy } = createRegistry()
+        const a = document.createElement('div')
+
+        registry.connect(a, 'hash-4')
+        registry.connect(a, 'hash-5')
+
+        await registry.remove(a, 'hash-4')
+
+        expect(cssRemoveSpy).toHaveBeenCalledTimes(1)
+        expect(cssRemoveSpy).toHaveBeenCalledWith('hash-4')
+
+        await registry.remove(a, 'hash-5')
+
+        expect(cssRemoveSpy).toHaveBeenCalledTimes(2)
+        expect(cssRemoveSpy).toHaveBeenCalledWith('hash-5')
+    })
+
+    it('ignores stale FinalizationRegistry callbacks fired after reset()', async () => {
+        const original = (globalThis as { FinalizationRegistry?: unknown }).FinalizationRegistry
+        let finalize: ((heldValue: { hash: string; generation: number }) => void) | undefined
+
+        ;(globalThis as { FinalizationRegistry?: unknown }).FinalizationRegistry = class {
+            constructor(callback: (heldValue: { hash: string; generation: number }) => void) {
+                finalize = callback
+            }
+            register() {}
+            unregister() {}
+        }
+
+        try {
+            const { registry, cssRemoveSpy } = createRegistry()
+            const a = document.createElement('div')
+
+            registry.connect(a, 'hash-7')
+            registry.reset()
+            registry.connect(a, 'hash-7')
+
+            // Simulate GC firing the stale (pre-reset) callback
+            finalize?.({ hash: 'hash-7', generation: 0 })
+
+            await Promise.resolve()
+            await Promise.resolve()
+
+            expect(cssRemoveSpy).not.toHaveBeenCalled()
+        } finally {
+            ;(globalThis as { FinalizationRegistry?: unknown }).FinalizationRegistry = original
+        }
+    })
+
+    it('falls back to counter-only cleanup when FinalizationRegistry is unavailable', async () => {
+        const original = (globalThis as { FinalizationRegistry?: unknown }).FinalizationRegistry
+
+        delete (globalThis as { FinalizationRegistry?: unknown }).FinalizationRegistry
+
+        try {
+            const { registry, cssRemoveSpy } = createRegistry()
+            const a = document.createElement('div')
+
+            registry.connect(a, 'hash-6')
+
+            await registry.remove(a, 'hash-6')
+
+            expect(cssRemoveSpy).toHaveBeenCalledTimes(1)
+            expect(cssRemoveSpy).toHaveBeenCalledWith('hash-6')
+        } finally {
+            ;(globalThis as { FinalizationRegistry?: unknown }).FinalizationRegistry = original
+        }
+    })
 })

--- a/packages/unistyles/src/__tests__/web-registry.spec.ts
+++ b/packages/unistyles/src/__tests__/web-registry.spec.ts
@@ -1,0 +1,80 @@
+/**
+ * @jest-environment jsdom
+ */
+import type { UnistylesServices } from '../web/types'
+
+// Stub the services singleton and CSSState to avoid the circular-import chain
+// (registry -> utils/unistyle -> services -> registry) that runs at module load.
+jest.mock('../web/services', () => ({ services: {} }))
+jest.mock('../web/css', () => ({
+    CSSState: class {
+        remove = jest.fn()
+        reset = jest.fn()
+    },
+}))
+
+// eslint-disable-next-line import/first
+import { UnistylesRegistry } from '../web/registry'
+
+const createRegistry = () => {
+    const registry = new UnistylesRegistry({} as UnistylesServices)
+    const cssRemoveSpy = registry.css.remove as jest.Mock
+
+    return { registry, cssRemoveSpy }
+}
+
+describe('UnistylesRegistry counter', () => {
+    afterEach(() => {
+        document.body.innerHTML = ''
+    })
+
+    it('cleans up the CSS rule only after every connect has a matching remove', async () => {
+        const { registry, cssRemoveSpy } = createRegistry()
+        const a = document.createElement('div')
+        const b = document.createElement('div')
+
+        registry.connect(a, 'hash-1')
+        registry.connect(b, 'hash-1')
+
+        await registry.remove(a, 'hash-1')
+
+        expect(cssRemoveSpy).not.toHaveBeenCalled()
+
+        await registry.remove(b, 'hash-1')
+
+        expect(cssRemoveSpy).toHaveBeenCalledTimes(1)
+        expect(cssRemoveSpy).toHaveBeenCalledWith('hash-1')
+    })
+
+    it('keeps the CSS rule alive when a new connect races the cleanup microtask', async () => {
+        const { registry, cssRemoveSpy } = createRegistry()
+        const a = document.createElement('div')
+        const b = document.createElement('div')
+
+        registry.connect(a, 'hash-2')
+        const pending = registry.remove(a, 'hash-2')
+
+        registry.connect(b, 'hash-2')
+
+        const removed = await pending
+
+        expect(removed).toBe(false)
+        expect(cssRemoveSpy).not.toHaveBeenCalled()
+    })
+
+    it('keeps the CSS rule alive when another element still carries the class', async () => {
+        const { registry, cssRemoveSpy } = createRegistry()
+        const tracked = document.createElement('div')
+        const untracked = document.createElement('div')
+
+        untracked.classList.add('hash-3')
+        document.body.appendChild(untracked)
+
+        registry.connect(tracked, 'hash-3')
+
+        const removed = await registry.remove(tracked, 'hash-3')
+
+        expect(removed).toBe(false)
+        expect(cssRemoveSpy).not.toHaveBeenCalled()
+    })
+})

--- a/packages/unistyles/src/web/registry.ts
+++ b/packages/unistyles/src/web/registry.ts
@@ -9,7 +9,12 @@ import { error, extractUnistyleDependencies, generateHash } from './utils'
 export class UnistylesRegistry {
     private readonly stylesheets = new Map<StyleSheetWithSuperPowers<StyleSheet>, StyleSheet>()
     private readonly stylesCache = new Set<string>()
-    private readonly stylesCounter = new Map<string, Set<HTMLElement>>()
+    // Use counter instead of Set<HTMLElement> to avoid retaining detached DOM nodes
+    // FR is a fallback when remove() is missed
+    private readonly stylesCounter = new Map<string, number>()
+    private readonly finalizationRegistry = new FinalizationRegistry<string>((hash) => {
+        this.decrementAndMaybeCleanup(hash)
+    })
     private readonly disposeListenersMap = new Map<object, VoidFunction>()
     private readonly dependenciesMap = new Map<StyleSheetWithSuperPowers<StyleSheet>, Set<UnistyleDependency>>()
     readonly css: CSSState
@@ -78,33 +83,45 @@ export class UnistylesRegistry {
     }
 
     connect = (ref: HTMLElement, hash: string) => {
-        const stylesCounter = this.stylesCounter.get(hash) ?? new Set()
-
-        stylesCounter.add(ref)
-        this.stylesCounter.set(hash, stylesCounter)
+        this.stylesCounter.set(hash, (this.stylesCounter.get(hash) ?? 0) + 1)
+        this.finalizationRegistry.register(ref, hash, ref)
     }
 
     remove = (ref: HTMLElement, hash: string) => {
-        const stylesCounter = this.stylesCounter.get(hash) ?? new Set()
+        this.finalizationRegistry.unregister(ref)
 
-        stylesCounter.delete(ref)
+        return this.decrementAndMaybeCleanup(hash)
+    }
 
-        if (stylesCounter.size === 0) {
-            // Move this to the end of the event loop so the element is removed from the DOM
-            return Promise.resolve().then(() => {
-                // Check if element is still in the DOM
-                if (document.querySelector(`.${hash}`)) {
-                    return false
-                }
+    private decrementAndMaybeCleanup = (hash: string): Promise<boolean> => {
+        const next = (this.stylesCounter.get(hash) ?? 0) - 1
 
-                this.css.remove(hash)
-                this.stylesCache.delete(hash)
+        if (next > 0) {
+            this.stylesCounter.set(hash, next)
 
-                return true
-            })
+            return Promise.resolve(false)
         }
 
-        return Promise.resolve(false)
+        // Drop the empty bucket from the Map
+        this.stylesCounter.delete(hash)
+
+        // Move this to the end of the event loop so the element is removed from the DOM
+        return Promise.resolve().then(() => {
+            // New connect raced in during the microtask
+            if ((this.stylesCounter.get(hash) ?? 0) > 0) {
+                return false
+            }
+
+            // Check if element is still in the DOM
+            if (document.querySelector(`.${hash}`)) {
+                return false
+            }
+
+            this.css.remove(hash)
+            this.stylesCache.delete(hash)
+
+            return true
+        })
     }
 
     add = (value: UnistylesValues, forChild?: boolean) => {

--- a/packages/unistyles/src/web/registry.ts
+++ b/packages/unistyles/src/web/registry.ts
@@ -12,9 +12,21 @@ export class UnistylesRegistry {
     // Use counter instead of Set<HTMLElement> to avoid retaining detached DOM nodes
     // FR is a fallback when remove() is missed
     private readonly stylesCounter = new Map<string, number>()
-    private readonly finalizationRegistry = new FinalizationRegistry<string>((hash) => {
-        this.decrementAndMaybeCleanup(hash)
-    })
+    // Bumped on reset() so stale FR callbacks are ignored
+    private cleanupGeneration = 0
+    // Per-registration unregister token, so remove() cancels only its own registration
+    private readonly finalizerTokens = new WeakMap<HTMLElement, Map<string, Array<object>>>()
+    // FR isn't available on every runtime - fall back to counter-only cleanup
+    private readonly finalizationRegistry =
+        typeof FinalizationRegistry === 'undefined'
+            ? undefined
+            : new FinalizationRegistry<{ hash: string; generation: number }>(({ hash, generation }) => {
+                  if (generation !== this.cleanupGeneration) {
+                      return
+                  }
+
+                  this.decrementAndMaybeCleanup(hash)
+              })
     private readonly disposeListenersMap = new Map<object, VoidFunction>()
     private readonly dependenciesMap = new Map<StyleSheetWithSuperPowers<StyleSheet>, Set<UnistyleDependency>>()
     readonly css: CSSState
@@ -84,11 +96,27 @@ export class UnistylesRegistry {
 
     connect = (ref: HTMLElement, hash: string) => {
         this.stylesCounter.set(hash, (this.stylesCounter.get(hash) ?? 0) + 1)
-        this.finalizationRegistry.register(ref, hash, ref)
+
+        if (!this.finalizationRegistry) {
+            return
+        }
+
+        const token = {}
+        const tokensByHash = this.finalizerTokens.get(ref) ?? new Map<string, Array<object>>()
+        const tokens = tokensByHash.get(hash) ?? []
+
+        tokens.push(token)
+        tokensByHash.set(hash, tokens)
+        this.finalizerTokens.set(ref, tokensByHash)
+        this.finalizationRegistry.register(ref, { hash, generation: this.cleanupGeneration }, token)
     }
 
     remove = (ref: HTMLElement, hash: string) => {
-        this.finalizationRegistry.unregister(ref)
+        const token = this.finalizerTokens.get(ref)?.get(hash)?.pop()
+
+        if (token) {
+            this.finalizationRegistry?.unregister(token)
+        }
 
         return this.decrementAndMaybeCleanup(hash)
     }
@@ -143,6 +171,8 @@ export class UnistylesRegistry {
     }
 
     reset = () => {
+        // Invalidate pending FR callbacks from this generation
+        this.cleanupGeneration += 1
         this.disposeListenersMap.forEach((dispose) => dispose())
         this.css.reset()
         this.stylesheets.clear()


### PR DESCRIPTION
## Summary

Follow-up to #1141. That PR fixed one missed `remove()` path on web. The underlying `stylesCounter` is still a `Map<string, Set<HTMLElement>>` though, so any other missed `remove()` (Suspense, forwardRef chains, SSR teardown like #1189) still leaks detached DOM nodes — the Set holds strong refs to the elements.

Switching `stylesCounter` to a `Map<string, number>` removes the retention risk. A `FinalizationRegistry` decrements the counter on GC, so missed `remove()` calls still clean up via the existing `document.querySelector` backstop. Empty Map buckets get dropped on drain too.

Heads up: `FinalizationRegistry` requires Chrome 74 / Safari 14.1 / Firefox 79. Happy to drop the FR and ship counter-only if that's a concern for any legacy targets. For example I use the unistyles lib on chrome 63 (tizen/webos smartv) but i think i can be an outlier

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Overhauled style cleanup to use per-hash reference counting with garbage-collection–based coordination, improving correctness across multiple hashes and DOM race scenarios.
  * Prevents stale cleanup from affecting current state after a reset, and performs immediate fallback cleanup when garbage-collection cleanup is unavailable.
* **Tests**
  * Expanded automated coverage for cleanup timing, race conditions, per-hash lifecycle behavior, and reset/GC edge cases to ensure `css.remove` is triggered at the right times.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->