### PR TITLE
fix: parse experimental_backgroundImage gradient string for shadow tree updates

### DIFF
--- a/packages/unistyles/cxx/core/UnistylesState.cpp
+++ b/packages/unistyles/cxx/core/UnistylesState.cpp
@@ -101,6 +101,10 @@ void core::UnistylesState::registerParseBoxShadowString(jsi::Function&& fn) {
     this->_parseBoxShadowStringFn = std::make_shared<jsi::Function>(std::move(fn));
 }
 
+void core::UnistylesState::registerParseBackgroundImageString(jsi::Function&& fn) {
+    this->_parseBackgroundImageStringFn = std::make_shared<jsi::Function>(std::move(fn));
+}
+
 int core::UnistylesState::parseColor(jsi::Runtime& rt, jsi::Value& maybeColor) {
     if (!maybeColor.isString()) {
         return 0;
@@ -123,6 +127,12 @@ int core::UnistylesState::parseColor(jsi::Runtime& rt, jsi::Value& maybeColor) {
 
 jsi::Array core::UnistylesState::parseBoxShadowString(jsi::Runtime& rt, std::string&& boxShadowString) {
     jsi::Value result = this->_parseBoxShadowStringFn.get()->call(rt, boxShadowString);
+
+    return result.asObject(rt).asArray(rt);
+}
+
+jsi::Array core::UnistylesState::parseBackgroundImageString(jsi::Runtime& rt, std::string&& backgroundImageString) {
+    jsi::Value result = this->_parseBackgroundImageStringFn.get()->call(rt, backgroundImageString);
 
     return result.asObject(rt).asArray(rt);
 }

--- a/packages/unistyles/cxx/core/UnistylesState.h
+++ b/packages/unistyles/cxx/core/UnistylesState.h
@@ -33,9 +33,11 @@ struct UnistylesState {
     jsi::Object getJSThemeByName(jsi::Runtime& rt, std::string& themeName);
     int parseColor(jsi::Runtime& rt, jsi::Value& color);
     jsi::Array parseBoxShadowString(jsi::Runtime& rt, std::string&& boxShadowString);
+    jsi::Array parseBackgroundImageString(jsi::Runtime& rt, std::string&& backgroundImageString);
     void computeCurrentBreakpoint(int screenWidth);
     void registerProcessColorFunction(jsi::Function&& fn);
     void registerParseBoxShadowString(jsi::Function&& fn);
+    void registerParseBackgroundImageString(jsi::Function&& fn);
 
 private:
     std::unordered_map<std::string, jsi::Value> _jsThemes{};
@@ -47,6 +49,7 @@ private:
     std::optional<std::string> _currentThemeName = std::nullopt;
     std::shared_ptr<jsi::Function> _processColorFn;
     std::shared_ptr<jsi::Function> _parseBoxShadowStringFn;
+    std::shared_ptr<jsi::Function> _parseBackgroundImageStringFn;
     std::unordered_map<std::string, uint32_t> _colorCache{};
 
     friend class UnistylesRegistry;

--- a/packages/unistyles/cxx/hybridObjects/HybridStyleSheet.cpp
+++ b/packages/unistyles/cxx/hybridObjects/HybridStyleSheet.cpp
@@ -247,13 +247,19 @@ void HybridStyleSheet::loadExternalMethods(const jsi::Value& thisValue, jsi::Run
 
     helpers::assertThat(rt, maybeParseBoxShadowStringFn.isObject(), "Unistyles: Can't load parseBoxShadowString function from JS.");
 
+    auto maybeProcessBackgroundImageFn = jsMethods.asObject(rt).getProperty(rt, "processBackgroundImage");
+
+    helpers::assertThat(rt, maybeProcessBackgroundImageFn.isObject(), "Unistyles: Can't load processBackgroundImage function from JS.");
+
     auto processColorFn = maybeProcessColorFn.asObject(rt).asFunction(rt);
     auto parseBoxShadowStringFn = maybeParseBoxShadowStringFn.asObject(rt).asFunction(rt);
+    auto processBackgroundImageFn = maybeProcessBackgroundImageFn.asObject(rt).asFunction(rt);
     auto& registry = core::UnistylesRegistry::get();
     auto& state = registry.getState();
 
     state.registerProcessColorFunction(std::move(processColorFn));
     state.registerParseBoxShadowString(std::move(parseBoxShadowStringFn));
+    state.registerParseBackgroundImageString(std::move(processBackgroundImageFn));
 }
 
 void HybridStyleSheet::onPlatformDependenciesChange(std::vector<UnistyleDependency> dependencies) {

--- a/packages/unistyles/cxx/parser/Parser.cpp
+++ b/packages/unistyles/cxx/parser/Parser.cpp
@@ -695,6 +695,13 @@ jsi::Array parser::Parser::parseBoxShadowString(jsi::Runtime& rt, std::string&& 
     return state.parseBoxShadowString(rt, std::move(boxShadowString));
 }
 
+jsi::Array parser::Parser::parseBackgroundImageString(jsi::Runtime& rt, std::string&& backgroundImageString) {
+    auto& registry = core::UnistylesRegistry::get();
+    auto& state = registry.getState();
+
+    return state.parseBackgroundImageString(rt, std::move(backgroundImageString));
+}
+
 // eg. [{ brightness: 0.5 }, { opacity: 0.25 }]
 jsi::Value parser::Parser::parseFilters(jsi::Runtime &rt, Unistyle::Shared unistyle, jsi::Object &obj) {
     std::vector<jsi::Value> parsedFilters{};
@@ -1072,6 +1079,16 @@ folly::dynamic parser::Parser::parseStylesToShadowTreeStyles(jsi::Runtime& rt, c
             rt,
             unistyleData->parsedStyle.value(),
             [this, &rt, &state, &convertedStyles](const std::string& propertyName, jsi::Value& propertyValue) {
+                if (propertyName == "experimental_backgroundImage" && propertyValue.isString()) {
+                    convertedStyles.setProperty(
+                        rt,
+                        propertyName.c_str(),
+                        this->parseBackgroundImageString(rt, propertyValue.asString(rt).utf8(rt))
+                    );
+
+                    return;
+                }
+
                 if (this->isColor(propertyName)) {
                     if (propertyValue.isString()) {
                         convertedStyles.setProperty(

--- a/packages/unistyles/cxx/parser/Parser.h
+++ b/packages/unistyles/cxx/parser/Parser.h
@@ -41,6 +41,7 @@ private:
     jsi::Value parseTransforms(jsi::Runtime& rt, Unistyle::Shared unistyle, jsi::Object& obj);
     jsi::Value parseBoxShadow(jsi::Runtime& rt, Unistyle::Shared unistyle, jsi::Object& obj);
     jsi::Array parseBoxShadowString(jsi::Runtime& rt, std::string&& boxShadowString);
+    jsi::Array parseBackgroundImageString(jsi::Runtime& rt, std::string&& backgroundImageString);
     jsi::Value parseFilters(jsi::Runtime& rt, Unistyle::Shared unistyle, jsi::Object& obj);
     jsi::Value getValueFromBreakpoints(jsi::Runtime& rt, Unistyle::Shared unistyle, jsi::Object& obj);
     jsi::Object parseVariants(jsi::Runtime& rt, Unistyle::Shared unistyle, jsi::Object& obj, Variants& variants);

--- a/packages/unistyles/src/mocks.ts
+++ b/packages/unistyles/src/mocks.ts
@@ -231,6 +231,7 @@ jest.mock('react-native-unistyles', () => {
             jsMethods: {
                 processColor: () => null,
                 parseBoxShadowString: () => [],
+                processBackgroundImage: () => [],
             },
             hairlineWidth: 1,
             addChangeListener: () => () => {},

--- a/packages/unistyles/src/specs/StyleSheet/index.ts
+++ b/packages/unistyles/src/specs/StyleSheet/index.ts
@@ -8,6 +8,11 @@ import type { CreateUnistylesStyleSheet } from '../../types'
 import type { UnistylesStyleSheet as UnistylesStyleSheetSpec } from './UnistylesStyleSheet.nitro'
 
 import { parseBoxShadowString } from '../../core/parseBoxShadow'
+// React Native has no public export for its background-image parser, but it is the
+// same processor the core renderer applies, so reusing it produces the exact array
+// shape native expects (the raw CSS string crashes the Android RCTView prop setter).
+// @ts-ignore - deep import has no type declarations
+import processBackgroundImage from 'react-native/Libraries/StyleSheet/processBackgroundImage'
 
 type UnistylesThemeSettings =
     | {
@@ -47,6 +52,7 @@ export interface UnistylesStyleSheet extends UnistylesStyleSheetSpec {
     jsMethods: {
         processColor: typeof processColor
         parseBoxShadowString: typeof parseBoxShadowString
+        processBackgroundImage: typeof processBackgroundImage
     }
 }
 
@@ -59,6 +65,7 @@ HybridUnistylesStyleSheet.compose = NativeStyleSheet.compose
 HybridUnistylesStyleSheet.jsMethods = {
     processColor,
     parseBoxShadowString,
+    processBackgroundImage,
 }
 
 HybridUnistylesStyleSheet.init()


### PR DESCRIPTION
## Summary

Fixes an Android crash when `experimental_backgroundImage` is updated on an already-mounted view:

```
com.facebook.react.bridge.JSApplicationIllegalArgumentException: Error while updating
property 'experimental_backgroundImage' of a view managed by: RCTView
  ...
Caused by: java.lang.ClassCastException: java.lang.String cannot be cast to
  com.facebook.react.bridge.ReadableArray
```

## Root cause

Dynamic updates are applied to the native view as raw props through `ShadowNodeFamily::nativeProps_DEPRECATED` (`ShadowTreeManager`), which bypasses React Native's JS style processors. RN normally runs `processBackgroundImage` to convert a `linear-gradient(...)` **string** into the structured **array** its views consume, and the Android `RCTView` prop setter is typed for that array (`ReadableArray`). Unistyles forwarded the raw string instead, so any update to `experimental_backgroundImage` on a mounted view tried to cast `String` → `ReadableArray` and threw.

This surfaces in practice when a view carrying a gradient is re-applied during a Reanimated-driven update (Unistyles re-injects styles onto affected nodes), e.g. animating a container around a focused `TextInput`. Static, mount-only gradients don't hit it because they flow through React's normal style-prop pipeline.

## Fix

Mirror the existing `boxShadow` handling: register RN's `processBackgroundImage` as a `jsMethod` and call it from C++.

The conversion happens in `parseStylesToShadowTreeStyles` (the shadow-tree / `nativeProps_DEPRECATED` path) and deliberately **not** in `parseFirstLevel`. `parseFirstLevel`'s output is also surfaced to React's `style` prop, where RN runs its own `processBackgroundImage`; converting there would double-process the value (RN's parser would then receive an already-parsed array and call `.toLowerCase()` on a structured `direction`, throwing `undefined is not a function`). Doing it only at the shadow-tree boundary keeps the React path untouched while giving native the array it expects.

## Changes

- `src/specs/StyleSheet/index.ts` – register `processBackgroundImage` as a `jsMethod`
- `src/mocks.ts` – add it to the mock
- `cxx/core/UnistylesState.{h,cpp}` – store the JS fn, add `parseBackgroundImageString`
- `cxx/hybridObjects/HybridStyleSheet.cpp` – load/register the fn
- `cxx/parser/Parser.{h,cpp}` – convert the string in `parseStylesToShadowTreeStyles`

## Testing

Verified on an Android emulator (New Architecture). Before: focusing a `TextInput` inside a container with a `linear-gradient` `experimental_backgroundImage` crashed with the exception above. After: no crash, gradient renders correctly, and static gradients render unchanged. `tsc`/`oxlint` clean on the changed source.

## Notes

- `processBackgroundImage` has no public RN export, so it's a deep import (`react-native/Libraries/StyleSheet/processBackgroundImage`) with `@ts-ignore`, the same module RN's own `ReactNativeStyleAttributes` uses internally.
- Same approach works on iOS; the symptom is Android-specific because of the Java prop-setter cast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive background image parsing support to the Unistyles styling system, enabling developers to apply background images in styled components. The feature integrates background image string processing into the core style pipeline, supporting consistent handling across platform conversions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->