### PR TITLE
fix: parse transformOrigin strings for shadow tree updates

### DIFF
--- a/packages/unistyles/android/CMakeLists.txt
+++ b/packages/unistyles/android/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.9.0)
 
 project(unistyles)
 
-file(GLOB_RECURSE CORE_SRC RELATIVE ${CMAKE_SOURCE_DIR} "../cxx/**/*.cpp")
+file(GLOB_RECURSE CORE_SRC CONFIGURE_DEPENDS RELATIVE ${CMAKE_SOURCE_DIR} "../cxx/*.cpp")
 file(GLOB_RECURSE PLATFORM_SRC RELATIVE ${CMAKE_SOURCE_DIR} "./src/main/cxx/*.cpp")
 
 if(ReactAndroid_VERSION_MINOR GREATER_EQUAL 80)

--- a/packages/unistyles/android/CMakeLists.txt
+++ b/packages/unistyles/android/CMakeLists.txt
@@ -21,6 +21,7 @@ include_directories(
     ./src/main/cxx
     ../cxx
     ../cxx/common
+    ../cxx/converters
     ../cxx/core
     ../cxx/hybridObjects
     ../cxx/parser

--- a/packages/unistyles/cxx/converters/BackgroundImageConverter.cpp
+++ b/packages/unistyles/cxx/converters/BackgroundImageConverter.cpp
@@ -1,0 +1,55 @@
+#include "BackgroundImageConverter.h"
+
+#include <algorithm>
+
+#if defined(RN_SERIALIZABLE_STATE) &&                                          \
+    __has_include(                                                             \
+        <react/renderer/components/view/BackgroundImagePropsConversions.h>)
+#include <react/renderer/components/view/BackgroundImagePropsConversions.h>
+#include <react/renderer/core/propsConversions.h>
+#define UNISTYLES_HAS_RN_BACKGROUND_IMAGE_PARSER 1
+#endif
+
+namespace margelo::nitro::unistyles::converters {
+
+bool isBackgroundImagePropName(const std::string &propertyName) {
+  return propertyName == "backgroundImage" ||
+         propertyName == "experimental_backgroundImage";
+}
+
+bool hasSafeBackgroundImageColorStops(const folly::dynamic &backgroundImages) {
+  if (!backgroundImages.isArray()) {
+    return false;
+  }
+
+  return std::all_of(
+      backgroundImages.begin(), backgroundImages.end(), [](const auto &image) {
+        if (!image.isObject() || image.count("colorStops") == 0) {
+          return false;
+        }
+
+        const auto &colorStops = image["colorStops"];
+
+        return colorStops.isArray() && colorStops.size() >= 2;
+      });
+}
+
+std::optional<folly::dynamic>
+parseBackgroundImageString(const std::string &backgroundImageString) {
+#ifdef UNISTYLES_HAS_RN_BACKGROUND_IMAGE_PARSER
+  std::vector<facebook::react::BackgroundImage> backgroundImages;
+
+  facebook::react::parseUnprocessedBackgroundImageString(backgroundImageString,
+                                                         backgroundImages);
+
+  auto parsedBackgroundImages = facebook::react::toDynamic(backgroundImages);
+
+  return hasSafeBackgroundImageColorStops(parsedBackgroundImages)
+             ? std::move(parsedBackgroundImages)
+             : folly::dynamic::array();
+#else
+  return std::nullopt;
+#endif
+}
+
+} // namespace margelo::nitro::unistyles::converters

--- a/packages/unistyles/cxx/converters/BackgroundImageConverter.h
+++ b/packages/unistyles/cxx/converters/BackgroundImageConverter.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <folly/dynamic.h>
+#include <optional>
+#include <string>
+
+namespace margelo::nitro::unistyles::converters {
+
+bool isBackgroundImagePropName(const std::string &propertyName);
+bool hasSafeBackgroundImageColorStops(const folly::dynamic &backgroundImages);
+std::optional<folly::dynamic>
+parseBackgroundImageString(const std::string &backgroundImageString);
+
+} // namespace margelo::nitro::unistyles::converters

--- a/packages/unistyles/cxx/converters/TransformOriginConverter.cpp
+++ b/packages/unistyles/cxx/converters/TransformOriginConverter.cpp
@@ -1,0 +1,33 @@
+#include "TransformOriginConverter.h"
+
+#if defined(RN_SERIALIZABLE_STATE) &&                                          \
+    __has_include(<react/renderer/components/view/conversions.h>)
+#include <react/renderer/components/view/conversions.h>
+#define UNISTYLES_HAS_RN_TRANSFORM_ORIGIN_PARSER 1
+#endif
+
+namespace margelo::nitro::unistyles::converters {
+
+bool isTransformOriginPropName(const std::string &propertyName) {
+  return propertyName == "transformOrigin";
+}
+
+std::optional<folly::dynamic>
+parseTransformOriginString(const std::string &transformOriginString) {
+#ifdef UNISTYLES_HAS_RN_TRANSFORM_ORIGIN_PARSER
+  facebook::react::TransformOrigin transformOrigin;
+
+  facebook::react::parseUnprocessedTransformOriginString(transformOriginString,
+                                                         transformOrigin);
+
+  if (!transformOrigin.isSet()) {
+    return folly::dynamic(nullptr);
+  }
+
+  return static_cast<folly::dynamic>(transformOrigin);
+#else
+  return std::nullopt;
+#endif
+}
+
+} // namespace margelo::nitro::unistyles::converters

--- a/packages/unistyles/cxx/converters/TransformOriginConverter.h
+++ b/packages/unistyles/cxx/converters/TransformOriginConverter.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <folly/dynamic.h>
+#include <optional>
+#include <string>
+
+namespace margelo::nitro::unistyles::converters {
+
+bool isTransformOriginPropName(const std::string &propertyName);
+std::optional<folly::dynamic>
+parseTransformOriginString(const std::string &transformOriginString);
+
+} // namespace margelo::nitro::unistyles::converters

--- a/packages/unistyles/cxx/hybridObjects/HybridShadowRegistry.cpp
+++ b/packages/unistyles/cxx/hybridObjects/HybridShadowRegistry.cpp
@@ -11,10 +11,11 @@ jsi::Value HybridShadowRegistry::link(jsi::Runtime &rt, const jsi::Value &thisVa
     std::vector<core::Unistyle::Shared> unistyleWrappers = core::unistyleFromValue(rt, args[1]);
     std::vector<std::vector<folly::dynamic>> arguments;
     auto& registry = core::UnistylesRegistry::get();
+    const bool wasSuspended = registry.isSuspended(&shadowNodeWrapper->getFamily());
 
     // this is special case for Animated, and prevents appending same unistyles to node
     // skip for suspended families - they need a full re-link with fresh UnistyleData
-    if (!registry.isSuspended(&shadowNodeWrapper->getFamily())) {
+    if (!wasSuspended) {
         registry.removeDuplicatedUnistyles(&shadowNodeWrapper->getFamily(), unistyleWrappers);
 
         if (unistyleWrappers.empty()) {
@@ -96,7 +97,7 @@ jsi::Value HybridShadowRegistry::link(jsi::Runtime &rt, const jsi::Value &thisVa
 
     std::optional<folly::dynamic> initialScopedUpdate;
 
-    if (scopedTheme.has_value()) {
+    if (scopedTheme.has_value() || wasSuspended) {
         initialScopedUpdate = parser.parseStylesToShadowTreeStyles(rt, unistylesData);
     }
 
@@ -106,6 +107,10 @@ jsi::Value HybridShadowRegistry::link(jsi::Runtime &rt, const jsi::Value &thisVa
         unistylesData,
         std::move(initialScopedUpdate)
     );
+
+    if (wasSuspended) {
+        shadow::ShadowTreeManager::updateShadowTree(rt);
+    }
 
     return jsi::Value::undefined();
 }

--- a/packages/unistyles/cxx/parser/Parser.cpp
+++ b/packages/unistyles/cxx/parser/Parser.cpp
@@ -2,6 +2,11 @@
 #include "UnistyleWrapper.h"
 #include <iomanip>
 #include <sstream>
+#if defined(RN_SERIALIZABLE_STATE) && __has_include(<react/renderer/components/view/BackgroundImagePropsConversions.h>)
+#include <react/renderer/components/view/BackgroundImagePropsConversions.h>
+#include <react/renderer/core/propsConversions.h>
+#define UNISTYLES_HAS_RN_BACKGROUND_IMAGE_PARSER 1
+#endif
 #include <react/renderer/css/CSSFilter.h>
 #include <react/renderer/css/CSSValueParser.h>
 
@@ -12,6 +17,11 @@ using namespace facebook::react;
 using Variants = std::vector<std::pair<std::string, std::string>>;
 
 namespace {
+
+bool isBackgroundImagePropName(const std::string& propertyName) {
+    return propertyName == "backgroundImage" ||
+        propertyName == "experimental_backgroundImage";
+}
 
 bool isSupportedLength(const CSSLength& length) {
     return length.unit == CSSLengthUnit::Px;
@@ -61,6 +71,20 @@ std::optional<jsi::Object> parseDropShadowString(jsi::Runtime& rt, const std::st
 
     return shadowObject;
 }
+
+#ifdef UNISTYLES_HAS_RN_BACKGROUND_IMAGE_PARSER
+std::optional<folly::dynamic> parseBackgroundImageString(const std::string& backgroundImageString) {
+    std::vector<BackgroundImage> backgroundImages;
+
+    parseUnprocessedBackgroundImageString(backgroundImageString, backgroundImages);
+
+    if (backgroundImages.empty()) {
+        return std::nullopt;
+    }
+
+    return toDynamic(backgroundImages);
+}
+#endif
 
 }
 
@@ -1072,6 +1096,30 @@ folly::dynamic parser::Parser::parseStylesToShadowTreeStyles(jsi::Runtime& rt, c
             rt,
             unistyleData->parsedStyle.value(),
             [this, &rt, &state, &convertedStyles](const std::string& propertyName, jsi::Value& propertyValue) {
+                if (isBackgroundImagePropName(propertyName) && propertyValue.isString()) {
+#ifdef UNISTYLES_HAS_RN_BACKGROUND_IMAGE_PARSER
+                    auto maybeBackgroundImage = parseBackgroundImageString(propertyValue.asString(rt).utf8(rt));
+
+                    if (maybeBackgroundImage.has_value()) {
+                        convertedStyles.setProperty(
+                            rt,
+                            propertyName.c_str(),
+                            jsi::valueFromDynamic(rt, maybeBackgroundImage.value())
+                        );
+
+                        return;
+                    }
+#endif
+
+                    convertedStyles.setProperty(
+                        rt,
+                        propertyName.c_str(),
+                        propertyValue
+                    );
+
+                    return;
+                }
+
                 if (this->isColor(propertyName)) {
                     if (propertyValue.isString()) {
                         convertedStyles.setProperty(

--- a/packages/unistyles/cxx/parser/Parser.cpp
+++ b/packages/unistyles/cxx/parser/Parser.cpp
@@ -2,6 +2,10 @@
 #include "UnistyleWrapper.h"
 #include <iomanip>
 #include <sstream>
+#if defined(RN_SERIALIZABLE_STATE) && __has_include(<react/renderer/components/view/conversions.h>)
+#include <react/renderer/components/view/conversions.h>
+#define UNISTYLES_HAS_RN_TRANSFORM_ORIGIN_PARSER 1
+#endif
 #include <react/renderer/css/CSSFilter.h>
 #include <react/renderer/css/CSSValueParser.h>
 
@@ -61,6 +65,20 @@ std::optional<jsi::Object> parseDropShadowString(jsi::Runtime& rt, const std::st
 
     return shadowObject;
 }
+
+#ifdef UNISTYLES_HAS_RN_TRANSFORM_ORIGIN_PARSER
+std::optional<folly::dynamic> parseTransformOriginString(const std::string& transformOriginString) {
+    TransformOrigin transformOrigin;
+
+    parseUnprocessedTransformOriginString(transformOriginString, transformOrigin);
+
+    if (!transformOrigin.isSet()) {
+        return std::nullopt;
+    }
+
+    return static_cast<folly::dynamic>(transformOrigin);
+}
+#endif
 
 }
 
@@ -1072,6 +1090,30 @@ folly::dynamic parser::Parser::parseStylesToShadowTreeStyles(jsi::Runtime& rt, c
             rt,
             unistyleData->parsedStyle.value(),
             [this, &rt, &state, &convertedStyles](const std::string& propertyName, jsi::Value& propertyValue) {
+                if (propertyName == "transformOrigin" && propertyValue.isString()) {
+#ifdef UNISTYLES_HAS_RN_TRANSFORM_ORIGIN_PARSER
+                    auto maybeTransformOrigin = parseTransformOriginString(propertyValue.asString(rt).utf8(rt));
+
+                    if (maybeTransformOrigin.has_value()) {
+                        convertedStyles.setProperty(
+                            rt,
+                            propertyName.c_str(),
+                            jsi::valueFromDynamic(rt, maybeTransformOrigin.value())
+                        );
+
+                        return;
+                    }
+#endif
+
+                    convertedStyles.setProperty(
+                        rt,
+                        propertyName.c_str(),
+                        propertyValue
+                    );
+
+                    return;
+                }
+
                 if (this->isColor(propertyName)) {
                     if (propertyValue.isString()) {
                         convertedStyles.setProperty(

--- a/packages/unistyles/cxx/parser/Parser.cpp
+++ b/packages/unistyles/cxx/parser/Parser.cpp
@@ -1,6 +1,7 @@
 #include "Parser.h"
 #include "UnistyleWrapper.h"
-#include "converters/BackgroundImageConverter.h"
+#include "BackgroundImageConverter.h"
+#include "TransformOriginConverter.h"
 #include <iomanip>
 #include <sstream>
 #include <react/renderer/css/CSSFilter.h>
@@ -1081,6 +1082,28 @@ folly::dynamic parser::Parser::parseStylesToShadowTreeStyles(jsi::Runtime& rt, c
                             rt,
                             propertyName.c_str(),
                             jsi::valueFromDynamic(rt, maybeBackgroundImage.value())
+                        );
+
+                        return;
+                    }
+
+                    convertedStyles.setProperty(
+                        rt,
+                        propertyName.c_str(),
+                        propertyValue
+                    );
+
+                    return;
+                }
+
+                if (converters::isTransformOriginPropName(propertyName) && propertyValue.isString()) {
+                    auto maybeTransformOrigin = converters::parseTransformOriginString(propertyValue.asString(rt).utf8(rt));
+
+                    if (maybeTransformOrigin.has_value()) {
+                        convertedStyles.setProperty(
+                            rt,
+                            propertyName.c_str(),
+                            jsi::valueFromDynamic(rt, maybeTransformOrigin.value())
                         );
 
                         return;

--- a/packages/unistyles/cxx/parser/Parser.cpp
+++ b/packages/unistyles/cxx/parser/Parser.cpp
@@ -1,12 +1,8 @@
 #include "Parser.h"
 #include "UnistyleWrapper.h"
+#include "converters/BackgroundImageConverter.h"
 #include <iomanip>
 #include <sstream>
-#if defined(RN_SERIALIZABLE_STATE) && __has_include(<react/renderer/components/view/BackgroundImagePropsConversions.h>)
-#include <react/renderer/components/view/BackgroundImagePropsConversions.h>
-#include <react/renderer/core/propsConversions.h>
-#define UNISTYLES_HAS_RN_BACKGROUND_IMAGE_PARSER 1
-#endif
 #include <react/renderer/css/CSSFilter.h>
 #include <react/renderer/css/CSSValueParser.h>
 
@@ -17,11 +13,6 @@ using namespace facebook::react;
 using Variants = std::vector<std::pair<std::string, std::string>>;
 
 namespace {
-
-bool isBackgroundImagePropName(const std::string& propertyName) {
-    return propertyName == "backgroundImage" ||
-        propertyName == "experimental_backgroundImage";
-}
 
 bool isSupportedLength(const CSSLength& length) {
     return length.unit == CSSLengthUnit::Px;
@@ -71,20 +62,6 @@ std::optional<jsi::Object> parseDropShadowString(jsi::Runtime& rt, const std::st
 
     return shadowObject;
 }
-
-#ifdef UNISTYLES_HAS_RN_BACKGROUND_IMAGE_PARSER
-std::optional<folly::dynamic> parseBackgroundImageString(const std::string& backgroundImageString) {
-    std::vector<BackgroundImage> backgroundImages;
-
-    parseUnprocessedBackgroundImageString(backgroundImageString, backgroundImages);
-
-    if (backgroundImages.empty()) {
-        return std::nullopt;
-    }
-
-    return toDynamic(backgroundImages);
-}
-#endif
 
 }
 
@@ -1096,9 +1073,8 @@ folly::dynamic parser::Parser::parseStylesToShadowTreeStyles(jsi::Runtime& rt, c
             rt,
             unistyleData->parsedStyle.value(),
             [this, &rt, &state, &convertedStyles](const std::string& propertyName, jsi::Value& propertyValue) {
-                if (isBackgroundImagePropName(propertyName) && propertyValue.isString()) {
-#ifdef UNISTYLES_HAS_RN_BACKGROUND_IMAGE_PARSER
-                    auto maybeBackgroundImage = parseBackgroundImageString(propertyValue.asString(rt).utf8(rt));
+                if (converters::isBackgroundImagePropName(propertyName) && propertyValue.isString()) {
+                    auto maybeBackgroundImage = converters::parseBackgroundImageString(propertyValue.asString(rt).utf8(rt));
 
                     if (maybeBackgroundImage.has_value()) {
                         convertedStyles.setProperty(
@@ -1109,7 +1085,6 @@ folly::dynamic parser::Parser::parseStylesToShadowTreeStyles(jsi::Runtime& rt, c
 
                         return;
                     }
-#endif
 
                     convertedStyles.setProperty(
                         rt,

--- a/packages/unistyles/package.json
+++ b/packages/unistyles/package.json
@@ -31,6 +31,7 @@
       "default": "./lib/commonjs/index.js"
     },
     "./mocks": {
+      "types": "./lib/typescript/src/mocks.d.ts",
       "import": "./lib/module/mocks.js",
       "browser": "./lib/module/mocks.js",
       "react-native": "./src/mocks.ts",

--- a/packages/unistyles/src/specs/ShadowRegistry/index.ts
+++ b/packages/unistyles/src/specs/ShadowRegistry/index.ts
@@ -19,12 +19,13 @@ interface ShadowRegistry extends UnistylesShadowRegistrySpec {
 const HybridShadowRegistry = NitroModules.createHybridObject<ShadowRegistry>('UnistylesShadowRegistry')
 
 const SUSPENSE_TAG = 13
+const OFFSCREEN_TAG = 22
 
 const isInsideSuspendedBoundary = (fiber: any): boolean => {
     let current = fiber?.return
 
     while (current) {
-        if (current.tag === SUSPENSE_TAG && current.memoizedState !== null) {
+        if ((current.tag === SUSPENSE_TAG || current.tag === OFFSCREEN_TAG) && current.memoizedState !== null) {
             return true
         }
 


### PR DESCRIPTION
## Summary

Parse string `transformOrigin` values before applying Unistyles shadow tree updates.

This follows the same boundary as #1209: the conversion happens only in `parseStylesToShadowTreeStyles`, using React Native's native `parseUnprocessedTransformOriginString` parser when the RN headers and `RN_SERIALIZABLE_STATE` conversion helpers are available.

## Why

React Native accepts CSS-like `transformOrigin` strings such as `top left`, but the Android native prop setter expects the processed array shape. During Unistyles theme/runtime-driven shadow tree updates, the raw string can bypass React Native's normal style processor and reach Android native props directly, causing a crash.

This change converts only string values in the shadow tree update path. Already processed array values such as `[0, 0, 0]` continue through the existing array handling.

The normal React style prop path is left untouched, so React Native can continue applying its own style processing there.

## Observed crash

We observed this on Android while switching theme with a style using `transformOrigin: 'top left'`:

```text
JSApplicationIllegalArgumentException: Error while updating property 'transformOrigin' of a view managed by: RCTText
Caused by: ClassCastException: java.lang.String cannot be cast to com.facebook.react.bridge.ReadableArray
```

That matches the raw string reaching Android's native prop setter instead of React Native's processed transform-origin array.

## Validation

- `bun run --cwd packages/unistyles check:ci`
- `../../node_modules/typescript/bin/tsc --noEmit` from `packages/unistyles`
- `bun run --cwd packages/unistyles test`
- `bun run --cwd packages/unistyles prepare`
- `./gradlew :app:assembleDebug` from `apps/example/android`
  - compiled `react-native-unistyles` C++ successfully for `arm64-v8a`, `armeabi-v7a`, `x86`, and `x86_64`
- Full precommit hook during commit


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added parsing support for the `transformOrigin` style property, converting string values into dynamic equivalents for React Native.
  * Added background-image conversion utilities to safely parse supported `backgroundImage`/`experimental_backgroundImage` strings.
* **Bug Fixes**
  * Improved suspended-boundary detection by treating Offscreen as suspended alongside Suspense (when applicable), improving shadow behavior consistency.
  * Ensured shadow tree styles are processed and shadow trees update correctly for suspended families.
* **Build / Packaging**
  * Updated Android build source inclusion and header search paths.
  * Extended mocks exports to include TypeScript types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->