### PR TITLE
fix: parse background image native props

### DIFF
--- a/packages/unistyles/android/CMakeLists.txt
+++ b/packages/unistyles/android/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.9.0)
 
 project(unistyles)
 
-file(GLOB_RECURSE CORE_SRC RELATIVE ${CMAKE_SOURCE_DIR} "../cxx/**/*.cpp")
+file(GLOB_RECURSE CORE_SRC CONFIGURE_DEPENDS RELATIVE ${CMAKE_SOURCE_DIR} "../cxx/*.cpp")
 file(GLOB_RECURSE PLATFORM_SRC RELATIVE ${CMAKE_SOURCE_DIR} "./src/main/cxx/*.cpp")
 
 if(ReactAndroid_VERSION_MINOR GREATER_EQUAL 80)

--- a/packages/unistyles/cxx/converters/BackgroundImageConverter.cpp
+++ b/packages/unistyles/cxx/converters/BackgroundImageConverter.cpp
@@ -1,0 +1,55 @@
+#include "BackgroundImageConverter.h"
+
+#include <algorithm>
+
+#if defined(RN_SERIALIZABLE_STATE) &&                                          \
+    __has_include(                                                             \
+        <react/renderer/components/view/BackgroundImagePropsConversions.h>)
+#include <react/renderer/components/view/BackgroundImagePropsConversions.h>
+#include <react/renderer/core/propsConversions.h>
+#define UNISTYLES_HAS_RN_BACKGROUND_IMAGE_PARSER 1
+#endif
+
+namespace margelo::nitro::unistyles::converters {
+
+bool isBackgroundImagePropName(const std::string &propertyName) {
+  return propertyName == "backgroundImage" ||
+         propertyName == "experimental_backgroundImage";
+}
+
+bool hasSafeBackgroundImageColorStops(const folly::dynamic &backgroundImages) {
+  if (!backgroundImages.isArray()) {
+    return false;
+  }
+
+  return std::all_of(
+      backgroundImages.begin(), backgroundImages.end(), [](const auto &image) {
+        if (!image.isObject() || image.count("colorStops") == 0) {
+          return false;
+        }
+
+        const auto &colorStops = image["colorStops"];
+
+        return colorStops.isArray() && colorStops.size() >= 2;
+      });
+}
+
+std::optional<folly::dynamic>
+parseBackgroundImageString(const std::string &backgroundImageString) {
+#ifdef UNISTYLES_HAS_RN_BACKGROUND_IMAGE_PARSER
+  std::vector<facebook::react::BackgroundImage> backgroundImages;
+
+  facebook::react::parseUnprocessedBackgroundImageString(backgroundImageString,
+                                                         backgroundImages);
+
+  auto parsedBackgroundImages = facebook::react::toDynamic(backgroundImages);
+
+  return hasSafeBackgroundImageColorStops(parsedBackgroundImages)
+             ? std::move(parsedBackgroundImages)
+             : folly::dynamic::array();
+#else
+  return std::nullopt;
+#endif
+}
+
+} // namespace margelo::nitro::unistyles::converters

--- a/packages/unistyles/cxx/converters/BackgroundImageConverter.h
+++ b/packages/unistyles/cxx/converters/BackgroundImageConverter.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <folly/dynamic.h>
+#include <optional>
+#include <string>
+
+namespace margelo::nitro::unistyles::converters {
+
+bool isBackgroundImagePropName(const std::string &propertyName);
+bool hasSafeBackgroundImageColorStops(const folly::dynamic &backgroundImages);
+std::optional<folly::dynamic>
+parseBackgroundImageString(const std::string &backgroundImageString);
+
+} // namespace margelo::nitro::unistyles::converters

--- a/packages/unistyles/cxx/parser/Parser.cpp
+++ b/packages/unistyles/cxx/parser/Parser.cpp
@@ -2,6 +2,11 @@
 #include "UnistyleWrapper.h"
 #include <iomanip>
 #include <sstream>
+#if defined(RN_SERIALIZABLE_STATE) && __has_include(<react/renderer/components/view/BackgroundImagePropsConversions.h>)
+#include <react/renderer/components/view/BackgroundImagePropsConversions.h>
+#include <react/renderer/core/propsConversions.h>
+#define UNISTYLES_HAS_RN_BACKGROUND_IMAGE_PARSER 1
+#endif
 #include <react/renderer/css/CSSFilter.h>
 #include <react/renderer/css/CSSValueParser.h>
 
@@ -12,6 +17,11 @@ using namespace facebook::react;
 using Variants = std::vector<std::pair<std::string, std::string>>;
 
 namespace {
+
+bool isBackgroundImagePropName(const std::string& propertyName) {
+    return propertyName == "backgroundImage" ||
+        propertyName == "experimental_backgroundImage";
+}
 
 bool isSupportedLength(const CSSLength& length) {
     return length.unit == CSSLengthUnit::Px;
@@ -61,6 +71,20 @@ std::optional<jsi::Object> parseDropShadowString(jsi::Runtime& rt, const std::st
 
     return shadowObject;
 }
+
+#ifdef UNISTYLES_HAS_RN_BACKGROUND_IMAGE_PARSER
+std::optional<folly::dynamic> parseBackgroundImageString(const std::string& backgroundImageString) {
+    std::vector<BackgroundImage> backgroundImages;
+
+    parseUnprocessedBackgroundImageString(backgroundImageString, backgroundImages);
+
+    if (backgroundImages.empty()) {
+        return std::nullopt;
+    }
+
+    return toDynamic(backgroundImages);
+}
+#endif
 
 }
 
@@ -1072,6 +1096,30 @@ folly::dynamic parser::Parser::parseStylesToShadowTreeStyles(jsi::Runtime& rt, c
             rt,
             unistyleData->parsedStyle.value(),
             [this, &rt, &state, &convertedStyles](const std::string& propertyName, jsi::Value& propertyValue) {
+                if (isBackgroundImagePropName(propertyName) && propertyValue.isString()) {
+#ifdef UNISTYLES_HAS_RN_BACKGROUND_IMAGE_PARSER
+                    auto maybeBackgroundImage = parseBackgroundImageString(propertyValue.asString(rt).utf8(rt));
+
+                    if (maybeBackgroundImage.has_value()) {
+                        convertedStyles.setProperty(
+                            rt,
+                            propertyName.c_str(),
+                            jsi::valueFromDynamic(rt, maybeBackgroundImage.value())
+                        );
+
+                        return;
+                    }
+#endif
+
+                    convertedStyles.setProperty(
+                        rt,
+                        propertyName.c_str(),
+                        propertyValue
+                    );
+
+                    return;
+                }
+
                 if (this->isColor(propertyName)) {
                     if (propertyValue.isString()) {
                         convertedStyles.setProperty(

--- a/packages/unistyles/cxx/parser/Parser.cpp
+++ b/packages/unistyles/cxx/parser/Parser.cpp
@@ -1,12 +1,8 @@
 #include "Parser.h"
 #include "UnistyleWrapper.h"
+#include "converters/BackgroundImageConverter.h"
 #include <iomanip>
 #include <sstream>
-#if defined(RN_SERIALIZABLE_STATE) && __has_include(<react/renderer/components/view/BackgroundImagePropsConversions.h>)
-#include <react/renderer/components/view/BackgroundImagePropsConversions.h>
-#include <react/renderer/core/propsConversions.h>
-#define UNISTYLES_HAS_RN_BACKGROUND_IMAGE_PARSER 1
-#endif
 #include <react/renderer/css/CSSFilter.h>
 #include <react/renderer/css/CSSValueParser.h>
 
@@ -17,11 +13,6 @@ using namespace facebook::react;
 using Variants = std::vector<std::pair<std::string, std::string>>;
 
 namespace {
-
-bool isBackgroundImagePropName(const std::string& propertyName) {
-    return propertyName == "backgroundImage" ||
-        propertyName == "experimental_backgroundImage";
-}
 
 bool isSupportedLength(const CSSLength& length) {
     return length.unit == CSSLengthUnit::Px;
@@ -71,20 +62,6 @@ std::optional<jsi::Object> parseDropShadowString(jsi::Runtime& rt, const std::st
 
     return shadowObject;
 }
-
-#ifdef UNISTYLES_HAS_RN_BACKGROUND_IMAGE_PARSER
-std::optional<folly::dynamic> parseBackgroundImageString(const std::string& backgroundImageString) {
-    std::vector<BackgroundImage> backgroundImages;
-
-    parseUnprocessedBackgroundImageString(backgroundImageString, backgroundImages);
-
-    if (backgroundImages.empty()) {
-        return std::nullopt;
-    }
-
-    return toDynamic(backgroundImages);
-}
-#endif
 
 }
 
@@ -1096,9 +1073,8 @@ folly::dynamic parser::Parser::parseStylesToShadowTreeStyles(jsi::Runtime& rt, c
             rt,
             unistyleData->parsedStyle.value(),
             [this, &rt, &state, &convertedStyles](const std::string& propertyName, jsi::Value& propertyValue) {
-                if (isBackgroundImagePropName(propertyName) && propertyValue.isString()) {
-#ifdef UNISTYLES_HAS_RN_BACKGROUND_IMAGE_PARSER
-                    auto maybeBackgroundImage = parseBackgroundImageString(propertyValue.asString(rt).utf8(rt));
+                if (converters::isBackgroundImagePropName(propertyName) && propertyValue.isString()) {
+                    auto maybeBackgroundImage = converters::parseBackgroundImageString(propertyValue.asString(rt).utf8(rt));
 
                     if (maybeBackgroundImage.has_value()) {
                         convertedStyles.setProperty(
@@ -1109,7 +1085,6 @@ folly::dynamic parser::Parser::parseStylesToShadowTreeStyles(jsi::Runtime& rt, c
 
                         return;
                     }
-#endif
 
                     convertedStyles.setProperty(
                         rt,


### PR DESCRIPTION
## Summary

This fixes Android gradient theme switches where Unistyles writes styles through the shadow-tree/native-props path. That path can bypass React Native's JS style processor, so Android receives a raw CSS string for `experimental_backgroundImage`/`backgroundImage` even though RCTView expects the processed background-image array.

The conversion now happens only in `parseStylesToShadowTreeStyles`, reusing React Native's native background-image parser when its headers and `RN_SERIALIZABLE_STATE` conversion helpers are available. The original prop key is preserved, so it supports both `experimental_backgroundImage` and the stable `backgroundImage` name from https://github.com/react/react-native/pull/57165 without touching React's normal style prop path.

Minimal repro: https://github.com/erickreutz/unistyles-gradient-android-repro

Repro patch: https://github.com/erickreutz/unistyles-gradient-android-repro/blob/main/patches/react-native-unistyles@3.2.4.patch

Validated with `bun run --cwd packages/unistyles check:ci`, `bun run --cwd packages/unistyles tsc`, `bun run --cwd packages/unistyles circular:check`, and `bun run --cwd packages/unistyles test`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for parsing and converting `backgroundImage` styles (including the experimental variant) into the shadow tree.
* **Bug Fixes / Improvements**
  * Improved handling of background image strings by validating parsed `colorStops` data and safely falling back to the original value when parsing fails or data is malformed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->