### PR TITLE
fix: add types condition for mocks export

### DIFF
--- a/packages/unistyles/package.json
+++ b/packages/unistyles/package.json
@@ -31,6 +31,7 @@
       "default": "./lib/commonjs/index.js"
     },
     "./mocks": {
+      "types": "./lib/typescript/src/mocks.d.ts",
       "import": "./lib/module/mocks.js",
       "browser": "./lib/module/mocks.js",
       "react-native": "./src/mocks.ts",


### PR DESCRIPTION
Fixes #1211

## Summary

Adds the missing `types` condition for the `react-native-unistyles/mocks` package export. Other typed subpath exports such as `./server`, `./web`, and `./reanimated` already include a `types` condition.

Without this condition, TypeScript projects using `moduleResolution: "bundler"` with the `react-native` custom condition can resolve `react-native-unistyles/mocks` to `src/mocks.ts` instead of the emitted `lib/typescript/src/mocks.d.ts`. That pulls Jest-only source internals into consumer typechecks.

## Verification

- `bun run --cwd packages/unistyles tsc`
- `bun run --cwd packages/unistyles test -- src/__tests__/mocks.spec.ts`
- `bun run --cwd packages/unistyles check:ci`
- `git commit` precommit hook, which ran package `tsc`, `lint`, `check`, `test`, and `circular:check`

I also verified with an isolated TypeScript resolver check that `react-native-unistyles/mocks` resolves to `lib/typescript/src/mocks.d.ts` under `moduleResolution: "bundler"` and `customConditions: ["react-native"]` after this export-map change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced TypeScript type definitions for the mocks module, providing improved IDE support and type safety when importing mocks from the package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->