### PR TITLE
fix: unistyles state ownership across runtimes on OTA/hard reload

### DIFF
--- a/packages/unistyles/android/src/main/cxx/NativeUnistylesModule.cpp
+++ b/packages/unistyles/android/src/main/cxx/NativeUnistylesModule.cpp
@@ -31,11 +31,17 @@ void UnistylesModule::registerNatives() {
 }
 
 jni::local_ref<BindingsInstallerHolder::javaobject> UnistylesModule::getBindingsInstaller(jni::alias_ref<UnistylesModule::javaobject> jobj) {
-    auto& runtimeExecutor = jobj->cthis()->_runtimeExecutor;
-    auto& nativePlatform = jobj->cthis()->_nativePlatform;
+    auto* self = jobj->cthis();
+    auto& runtimeExecutor = self->_runtimeExecutor;
+    auto& nativePlatform = self->_nativePlatform;
 
-    return BindingsInstallerHolder::newObjectCxxArgs([&runtimeExecutor, &nativePlatform](jsi::Runtime& rt) {
+    return BindingsInstallerHolder::newObjectCxxArgs([self, &runtimeExecutor, &nativePlatform](jsi::Runtime& rt) {
         // function is called on: first init and every live reload
+        // claim ownership of Unistyles state for this runtime (newest install wins); this
+        // also wipes a previous runtime's now-defunct state on a live/OTA reload
+        self->_runtime = &rt;
+        core::UnistylesRegistry::get().takeOwnership(&rt);
+
         // check if this is live reload, if so let's replace UnistylesRuntime with new runtime
         auto hasUnistylesRuntime = HybridObjectRegistry::hasHybridObject("UnistylesRuntime");
 

--- a/packages/unistyles/android/src/main/cxx/NativeUnistylesModule.h
+++ b/packages/unistyles/android/src/main/cxx/NativeUnistylesModule.h
@@ -29,7 +29,12 @@ struct UnistylesModule : public jni::HybridClass<UnistylesModule> {
         jni::alias_ref<JHybridNativePlatformSpec::JavaPart> nativePlatform
     );
     static void invalidateNative(jni::alias_ref<jhybridobject> jThis) {
-        core::UnistylesRegistry::get().destroy();
+        auto* self = jThis->cthis();
+
+        // See UnistylesModuleOnLoad.mm: releases ownership and wipes state only if this
+        // runtime is still the owner, so a superseded runtime's late teardown during an
+        // OTA hard reload can't clear the new runtime's freshly configured state.
+        core::UnistylesRegistry::get().releaseOwnership(self->_runtime);
     }
 
     static jni::local_ref<BindingsInstallerHolder::javaobject> getBindingsInstaller(jni::alias_ref<UnistylesModule::javaobject> jThis);
@@ -37,6 +42,7 @@ struct UnistylesModule : public jni::HybridClass<UnistylesModule> {
 private:
     RuntimeExecutor _runtimeExecutor;
     std::shared_ptr<HybridNativePlatformSpec> _nativePlatform;
+    jsi::Runtime* _runtime = nullptr;
 };
 
 }

--- a/packages/unistyles/cxx/core/UnistylesRegistry.h
+++ b/packages/unistyles/cxx/core/UnistylesRegistry.h
@@ -2,6 +2,7 @@
 
 #include "set"
 #include <atomic>
+#include <mutex>
 #include <jsi/jsi.h>
 #include <folly/dynamic.h>
 #include <react/renderer/uimanager/UIManager.h>
@@ -54,9 +55,51 @@ struct UnistylesRegistry: public StyleSheetRegistry {
     core::Unistyle::Shared getUnistyleById(std::string unistyleID);
     void destroy();
 
+    // Tracks the JS runtime that currently owns Unistyles state and arbitrates who may
+    // wipe the (single, global) state. On an OTA / hard reload the previous runtime is
+    // torn down asynchronously while the new runtime has already installed its bindings
+    // and re-created the state; without arbitration the previous runtime's late teardown
+    // would clear the new runtime's freshly configured state and crash with "Unistyles
+    // was loaded, but it's not configured". Runtime pointers are only ever compared for
+    // identity, never dereferenced, so a stale pointer is safe.
+
+    // A runtime claims ownership when it installs its bindings (newest wins). If a
+    // different runtime owned the state before, that state is now defunct, so wipe it
+    // here — as the successor — rather than relying on the previous runtime's racy async
+    // teardown that shares this same global state.
+    void takeOwnership(jsi::Runtime* rt) {
+        // Lock so the check-and-destroy below is atomic w.r.t. releaseOwnership, which
+        // runs on a different thread during an OTA hard reload. Without it, a superseded
+        // runtime's releaseOwnership could pass its owner check, get preempted while this
+        // runtime configures, then resume and destroy() the new state.
+        std::lock_guard<std::mutex> lock(this->_ownershipMutex);
+
+        if (this->_activeRuntime != nullptr && this->_activeRuntime != rt) {
+            this->destroy();
+        }
+
+        this->_activeRuntime = rt;
+    }
+
+    // A runtime releases ownership when it is invalidated. Only the current owner may
+    // wipe — a runtime that was already superseded was cleaned up when its successor
+    // took ownership, so its late teardown must not touch the new owner's state.
+    void releaseOwnership(jsi::Runtime* rt) {
+        // Serialized with takeOwnership (see above) so the check-and-destroy is atomic
+        // and a late teardown can't wipe a newer runtime's freshly configured state.
+        std::lock_guard<std::mutex> lock(this->_ownershipMutex);
+
+        if (this->_activeRuntime == rt) {
+            this->destroy();
+            this->_activeRuntime = nullptr;
+        }
+    }
+
 private:
     UnistylesRegistry() = default;
 
+    jsi::Runtime* _activeRuntime = nullptr;
+    std::mutex _ownershipMutex;
     static std::atomic<int> _nextStyleSheetTag;
     std::optional<std::string> _scopedTheme{};
     std::unique_ptr<UnistylesState> _state{};

--- a/packages/unistyles/ios/UnistylesModuleOnLoad.mm
+++ b/packages/unistyles/ios/UnistylesModuleOnLoad.mm
@@ -6,7 +6,12 @@
 
 using namespace margelo::nitro;
 
-@implementation UnistylesModule
+@implementation UnistylesModule {
+    // The JS runtime this module instance installed its bindings for. Compared
+    // against the registry's active runtime on teardown so a late invalidation of a
+    // previous runtime can't wipe a newer runtime's state during an OTA hard reload.
+    jsi::Runtime* _runtime;
+}
 
 RCT_EXPORT_MODULE(Unistyles)
 
@@ -16,6 +21,11 @@ RCT_EXPORT_MODULE(Unistyles)
 
 - (void)installJSIBindingsWithRuntime:(jsi::Runtime&)rt callInvoker:(const std::shared_ptr<facebook::react::CallInvoker> &)callInvoker {
     // function is called on: first init and every live reload
+    // claim ownership of Unistyles state for this runtime (newest install wins); this
+    // also wipes a previous runtime's now-defunct state on a live/OTA reload
+    _runtime = &rt;
+    core::UnistylesRegistry::get().takeOwnership(&rt);
+
     // check if this is live reload, if so let's replace UnistylesRuntime with new runtime
     auto hasUnistylesRuntime = HybridObjectRegistry::hasHybridObject("UnistylesRuntime");
 
@@ -53,7 +63,10 @@ RCT_EXPORT_MODULE(Unistyles)
 }
 
 - (void)invalidate {
-    core::UnistylesRegistry::get().destroy();
+    // Releases ownership and wipes state only if this runtime is still the owner.
+    // During an OTA hard reload a newer runtime has already taken ownership, so this
+    // (superseded) runtime's late teardown is a no-op and won't clear the new state.
+    core::UnistylesRegistry::get().releaseOwnership(_runtime);
 
     [super invalidate];
 }


### PR DESCRIPTION
## Summary

During an OTA or hard reload the previous JS runtime is torn down asynchronously while the new runtime has already installed its bindings and re-created the (single, global) Unistyles state. The previous runtime's late teardown then wipes the new runtime's freshly configured state, crashing with:

▎ Unistyles was loaded, but it's not configured

### Fix

Track the runtime that currently owns the state in UnistylesRegistry and arbitrate who may wipe it:

- A runtime claims ownership when it installs its bindings (newest wins), wiping the now-defunct previous runtime's state as the successor.
- Only the current owner may wipe on invalidation. A superseded runtime's late teardown becomes a no-op.
- Ownership transitions are serialized with a std::mutex so the check-and-destroy is atomic across threads (teardown and install run on different threads during an OTA hard reload).

Runtime pointers are only ever compared for identity, never dereferenced, so a stale pointer is safe.

### Changes

- `cxx/core/UnistylesRegistry.h` — takeOwnership / releaseOwnership with mutex-guarded arbitration.
- `ios/UnistylesModuleOnLoad.mm`— claim ownership on installJSIBindings, release on invalidate.
- `android/src/main/cxx/NativeUnistylesModule.cpp /.h` — claim ownership in `getBindingsInstaller`, release in `invalidateNative`.

### Test plan

- [x] Trigger an OTA / hard reload and confirm the "Unistyles was loaded, but it's not configured" crash no longer occurs.
- [x] Verify normal live reload still re-creates the runtime correctly.