### PR TITLE
fix(web): guard screen.orientation for browsers without the Screen Orientation API

### DIFF
--- a/packages/unistyles/src/web/runtime.ts
+++ b/packages/unistyles/src/web/runtime.ts
@@ -76,7 +76,10 @@ export class UnistylesRuntime {
     }
 
     get orientation() {
-        if (isServer()) {
+        // `screen.orientation` is undefined in browsers without the Screen
+        // Orientation API (e.g. iOS Safari <= 16.3). Guard it so the runtime
+        // does not throw during initialization on those browsers.
+        if (isServer() || !screen.orientation) {
             return Orientation.Portrait
         }
 


### PR DESCRIPTION
## Summary

Fixes #1073.

`screen.orientation` is `undefined` in browsers that don't implement the [Screen Orientation API](https://caniuse.com/screen-orientation) — notably iOS Safari ≤ 16.3. The web runtime's `orientation` getter reads `screen.orientation.type` unconditionally:

```ts
get orientation() {
    if (isServer()) {
        return Orientation.Portrait
    }

    return screen.orientation.type.includes('portrait') ? Orientation.Portrait : Orientation.Landscape
}
```

On those browsers this throws a `TypeError` during runtime initialization (triggered by `StyleSheet.create()` at module scope), which renders a blank page with no styles — exactly the symptom reported in #1073.

## Change

Guard the access and fall back to `Orientation.Portrait` when `screen.orientation` is unavailable, matching the existing server-side default:

```ts
if (isServer() || !screen.orientation) {
    return Orientation.Portrait
}
```

## Notes

- Minimal, behavior-preserving for browsers that support the API.
- The `orientationchange` listener in `web/listener.ts` uses `window.addEventListener`, which is safe on these browsers, so no change is needed there.
- Happy to add a test if you'd like — let me know which harness you'd prefer for the web runtime.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with server-rendered applications and older browsers.
  * Prevented errors when the Screen Orientation API is unavailable by safely defaulting to portrait orientation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->