### PR TITLE
fix: throw JSError instead of crashing when uni__getStyles races registry teardown

### DIFF
--- a/packages/unistyles/cxx/core/UnistyleWrapper.h
+++ b/packages/unistyles/cxx/core/UnistyleWrapper.h
@@ -158,6 +158,16 @@ inline static jsi::Value objectFromUnistyle(jsi::Runtime& rt, std::shared_ptr<Hy
     ) {
         auto& registry = UnistylesRegistry::get();
         auto unistyle = registry.getUnistyleById(unistyleID);
+
+        // the unistyle may have been unregistered while this call was in flight,
+        // eg. UnistylesRegistry::destroy() runs during a reload while the outgoing
+        // runtime still executes queued work — throw instead of dereferencing nullptr
+        if (unistyle == nullptr) {
+            throw jsi::JSError(rt, R"(Unistyles: Style is no longer registered!
+
+You likely accessed a style while the runtime was being torn down (eg. during a reload).)");
+        }
+
         auto scopedTheme = registry.getScopedTheme();
         parser::Parser parser(unistylesRuntime);
 


### PR DESCRIPTION
## Summary

Fixes #1220.

`UnistylesRegistry::destroy()` (run by the TurboModule `invalidate` during a reload) clears `_styleSheetRegistry` while the outgoing JS runtime can still execute queued work for a moment. A `uni__getStyles` host-function call in that window — `withUnistyles`, or the `Pressable` wrapper's `getStyles()` on any render/ref-attach/press — gets `nullptr` back from `registry.getUnistyleById(unistyleID)` and crashes natively on the first dereference inside `Parser::rebuildUnistyle` (`EXC_BAD_ACCESS`, `Parser.cpp:390` on 3.2.5). Full mechanism, stack traces, and production telemetry are in the issue.

This change null-checks the lookup and throws a `jsi::JSError` instead, mirroring the existing null-checked hash-key fallback in `unistylesFromNonExistentNativeState` ("Unistyles: Style is not bound!"). The failure becomes catchable JS — an error boundary can recover — instead of a process crash. The check also covers the `unistyle->styleKey` dereference in the scoped-theme branch, which sits before `rebuildUnistyle` on the same null path.

## Test plan

- Compile-verified against React Native 0.86.0 / Hermes / New Architecture (iOS, `xcodebuild` on the Unistyles pod target inside a production app's Pods project).
- The throw path matches the existing pattern at `unistylesFromNonExistentNativeState` (same file), which our fleet telemetry shows is caught cleanly by React error boundaries in the identical teardown window.
- No behavior change when the registry lookup succeeds (the only code added is the null branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability during reloads by safely handling styles that are unregistered while being accessed.
  * Displays a clear error instead of causing a crash when a style is no longer available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->