### PR TITLE
fix(iOS): treat React Native's 1000.0.0 dev placeholder as a new version in the RN version guards

### DIFF
--- a/packages/unistyles/cxx/hybridObjects/HybridShadowRegistry.cpp
+++ b/packages/unistyles/cxx/hybridObjects/HybridShadowRegistry.cpp
@@ -170,7 +170,9 @@ jsi::Value HybridShadowRegistry::getScopedTheme(jsi::Runtime &rt, const jsi::Val
 }
 
 std::shared_ptr<const core::ShadowNode> HybridShadowRegistry::getShadowNodeFromRef(jsi::Runtime& rt, const jsi::Value& maybeRef) {
-#if REACT_NATIVE_VERSION_MINOR >= 81
+// MAJOR > 0 covers future 1.x releases and React Native's in-tree dev
+// placeholder 1000.0.0, which prebuilt-core artifacts can report.
+#if REACT_NATIVE_VERSION_MAJOR > 0 || REACT_NATIVE_VERSION_MINOR >= 81
     return Bridging<std::shared_ptr<const ShadowNode>>::fromJs(rt, maybeRef);
 #else
     return shadowNodeFromValue(rt, maybeRef);

--- a/packages/unistyles/cxx/shadowTree/ShadowTreeManager.cpp
+++ b/packages/unistyles/cxx/shadowTree/ShadowTreeManager.cpp
@@ -16,7 +16,9 @@ void shadow::ShadowTreeManager::updateShadowTree(jsi::Runtime& rt) {
             return;
         }
 
-#if REACT_NATIVE_VERSION_MINOR >= 81
+// MAJOR > 0 covers future 1.x releases and React Native's in-tree dev
+// placeholder 1000.0.0, which prebuilt-core artifacts can report.
+#if REACT_NATIVE_VERSION_MAJOR > 0 || REACT_NATIVE_VERSION_MINOR >= 81
         std::unordered_map<Tag, folly::dynamic> tagToProps;
 
         for (const auto& [family, props] : updates) {


### PR DESCRIPTION
# fix(iOS): treat React Native's 1000.0.0 dev placeholder as a new version in the RN version guards

## Summary

The `[ios] react-native-unistyles` job in react-native-community/nightly-tests fails against `react-native@0.88.0-nightly-20260717` ([run](https://github.com/react-native-community/nightly-tests/actions/runs/29559977839/job/87820208692)):

```
HybridShadowRegistry.cpp:176:12: error: use of undeclared identifier 'shadowNodeFromValue'; did you mean 'shadowNodeListFromValue'?
```

The failing line is the `#else` (pre-0.81) branch of an RN version guard — i.e. the guard itself misfired, not the code:

```cpp
#if REACT_NATIVE_VERSION_MINOR >= 81
    return Bridging<std::shared_ptr<const ShadowNode>>::fromJs(rt, maybeRef);
#else
    return shadowNodeFromValue(rt, maybeRef);   // removed from RN in 0.81 (facebook/react-native#51676)
#endif
```

### Why the guard misfires

React Native's in-tree `ReactCommon/cxxreact/ReactNativeVersion.h` carries a dev placeholder — `MAJOR 1000 / MINOR 0` — that `set-version.js` replaces at publish time. The npm package is stamped correctly (`0 / 88`), but the **prebuilt-core artifacts** (`RCT_USE_PREBUILT_RNCORE=1`, which nightly-tests exercises) currently ship headers composed from the unstamped tree. Since RN's 0.88 nightlies resolve core headers from the prebuilt artifact rather than the npm package, `REACT_NATIVE_VERSION_MINOR` evaluates to `0` and the guard selects the pre-0.81 branch against a 0.88 core.

That artifact-side stamping is an RN bug and will be fixed there — but the already-published nightlies are immutable, and treating the documented dev placeholder as "newest" is cheap and makes the guard robust for future RN 1.x too.

### Fix

At both guard sites (`HybridShadowRegistry.cpp`, `ShadowTreeManager.cpp`):

```cpp
#if REACT_NATIVE_VERSION_MAJOR > 0 || REACT_NATIVE_VERSION_MINOR >= 81
```

- RN 0.81+ → true via `MINOR`
- future RN 1.x → true via `MAJOR` (the old check would have regressed to the legacy branch)
- dev placeholder 1000.0.0 → true via `MAJOR`
- very old RN / macro undefined → false, legacy branch, unchanged behavior

## Test plan

Fresh RN app on `react-native@0.88.0-nightly-20260717-b33de750b` with `react-native-unistyles@3.3.0` + nitro-modules + edge-to-edge, built with the prebuilt-core flags nightly-tests uses (`RCT_USE_RN_DEP=1 RCT_USE_PREBUILT_RNCORE=1`), Xcode 26.6:

- Stock 3.3.0: reproduces the `shadowNodeFromValue` compile error locally.
- With the two patched files: build succeeds.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with React Native 1.x and later versions.
  * Updated shadow handling and tree updates to use the appropriate behavior for newer React Native releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->