### PR TITLE
fix: crash when NativeText/NativeView render before RN registers the view config

### DIFF
--- a/packages/unistyles/src/components/native/NativeText.native.tsx
+++ b/packages/unistyles/src/components/native/NativeText.native.tsx
@@ -1,7 +1,9 @@
 import type { TextProps } from 'react-native'
 
 import { type ComponentType, createElement, forwardRef } from 'react'
-
+// registers the RCTText view config as a module side effect,
+// otherwise createElement('RCTText') throws when no <Text> has mounted yet
+import 'react-native/Libraries/Text/TextNativeComponent'
 import { createUnistylesElement } from '../../core'
 
 // credits to @hirbod

--- a/packages/unistyles/src/components/native/NativeView.native.tsx
+++ b/packages/unistyles/src/components/native/NativeView.native.tsx
@@ -1,7 +1,9 @@
 import type { ViewProps } from 'react-native'
 
 import { type ComponentType, createElement, forwardRef } from 'react'
-
+// registers the RCTView view config as a module side effect,
+// otherwise createElement('RCTView') throws when no <View> has mounted yet
+import 'react-native/Libraries/Components/View/ViewNativeComponent'
 import { createUnistylesElement } from '../../core'
 
 // credits to @hirbod


### PR DESCRIPTION
## Summary

In our production app, we have  one component  that deep-imports `NativeText` from `react-native/Libraries/Text/TextNativeComponent` to render raw text on a hot path. The babel plugin remaps that import to Unistyles' `LeanText`, and on one boot path (restart into RTL after switching the app language to Arabic) it renders **before any regular `<Text>` has mounted**, crashing the app on every subsequent launch:

> Invariant Violation: View config getter callback for component `RCTText` must be a function (received `undefined`)

### Root cause

`LeanText` / `LeanView` resolve the host component **by string name**:

```tsx
const LeanText = forwardRef((props, ref) => createElement('RCTText', { ...props, ref }))
```

That string lookup only succeeds if React Native's own `TextNativeComponent` module has already evaluated — its top-level `createReactNativeComponentClass('RCTText', ...)` call is what registers the view config getter. Normally that happens as a side effect of the first regular `<Text>` initializing, but with Metro inline requires the timing is load-order dependent. The factory consumes a registration invariant that it neither establishes nor imports — whether it holds depends on which component happens to render first in the consumer app.

The same latent hazard exists for `LeanView` / `RCTView` (registered by `ViewNativeComponent` via `NativeComponentRegistry.get`, also a module side effect).

### Fix

A side-effect import of the corresponding RN module inside each factory file. Since these modules only evaluate lazily, right before the factory's first render, the import guarantees registration by construction — for every consumer, regardless of bundler require ordering, at zero runtime cost (the module was going to be loaded anyway, and the render path is untouched).

`tsc --noEmit` and `oxlint` pass. Verified by reproducing the crash in an RN 0.83 (New Architecture) app and confirming the boot path renders correctly with the side-effect import in place.

### Alternative considered

Rendering the module's export instead of the string — `createElement(RNNativeText, ...)` where `RNNativeText` is imported from `TextNativeComponent`. At runtime that export *is* the string `'RCTText'` (the return value of `createReactNativeComponentClass`), so behavior would be identical while making the registration inseparable from obtaining the value. Went with the bare import because RN's internals are flow-typed, so the named import would need a new module declaration on your side — but happy to switch if you prefer that shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where text and view elements could fail to render when used before a native React Native component had mounted.
  * Improved reliability for lightweight text and view rendering on native platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->