### PR TITLE
fix(types): accept readonly arrays for boxShadow

### DIFF
--- a/packages/unistyles/src/types/stylesheet.ts
+++ b/packages/unistyles/src/types/stylesheet.ts
@@ -19,7 +19,7 @@ type UnistyleNestedStyles = {
     shadowOffset?: ToDeepUnistyles<ShadowOffset>
     textShadowOffset?: ToDeepUnistyles<ShadowOffset>
     transform?: Array<ToDeepUnistyles<TransformStyles>>
-    boxShadow?: Array<ToDeepUnistyles<BoxShadowValue>> | string
+    boxShadow?: ReadonlyArray<ToDeepUnistyles<BoxShadowValue>> | string
     filter?: Array<ToDeepUnistyles<FilterFunction>> | string
 }
 


### PR DESCRIPTION
## Problem

`boxShadow` in `StyleSheet.create` is typed as `Array<ToDeepUnistyles<BoxShadowValue>>` (mutable), so a `readonly`/`as const` array of shadow values — as produced by design-system token libraries — fails to assign, even though React Native itself types it as `ReadonlyArray<BoxShadowValue> | string`. Unistyles was stricter than RN.

## Fix

Widen the type to `ReadonlyArray<…>`, matching React Native.

```ts
boxShadow?: ReadonlyArray<ToDeepUnistyles<BoxShadowValue>> | string
```

Closes #1214

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated `boxShadow` styling types to accept read-only arrays, improving compatibility with immutable style definitions.
  * Preserved support for string-based `boxShadow` values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->