### PR TITLE
fix: keep StyleSheet.absoluteFillObject a real style object

### DIFF
--- a/packages/unistyles/src/specs/StyleSheet/index.ts
+++ b/packages/unistyles/src/specs/StyleSheet/index.ts
@@ -34,8 +34,18 @@ export type UnistylesConfig = {
     breakpoints?: UnistylesBreakpoints
 }
 
+// `absoluteFill` may resolve to a registered numeric style id (web / older RN), so keep
+// `absoluteFillObject` a real descriptor object to stay spreadable and match RN's contract
+const absoluteFillObject = {
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    top: 0,
+    bottom: 0,
+} as const
+
 export interface UnistylesStyleSheet extends UnistylesStyleSheetSpec {
-    absoluteFillObject: typeof NativeStyleSheetType.absoluteFill
+    absoluteFillObject: typeof absoluteFillObject
     absoluteFill: typeof NativeStyleSheetType.absoluteFill
     compose: typeof NativeStyleSheetType.compose
     flatten: typeof NativeStyleSheetType.flatten
@@ -52,7 +62,7 @@ export interface UnistylesStyleSheet extends UnistylesStyleSheetSpec {
 
 const HybridUnistylesStyleSheet = NitroModules.createHybridObject<UnistylesStyleSheet>('UnistylesStyleSheet')
 
-HybridUnistylesStyleSheet.absoluteFillObject = NativeStyleSheet.absoluteFill
+HybridUnistylesStyleSheet.absoluteFillObject = absoluteFillObject
 HybridUnistylesStyleSheet.absoluteFill = NativeStyleSheet.absoluteFill
 HybridUnistylesStyleSheet.flatten = NativeStyleSheet.flatten
 HybridUnistylesStyleSheet.compose = NativeStyleSheet.compose


### PR DESCRIPTION
## Problem

`StyleSheet.absoluteFillObject` is aliased to `NativeStyleSheet.absoluteFill`, which resolves to a registered **numeric style id** on web / older RN. As a result:

- `...StyleSheet.absoluteFillObject` fails to compile (`TS2698: Spread types may only be created from object types`)
- at runtime on web the value is a number, not the `{ position: 'absolute', top: 0, left: 0, right: 0, bottom: 0 }` descriptor

This diverges from React Native, where `absoluteFillObject` is always the real style object.

## Fix

Point `absoluteFillObject` at a concrete descriptor object (single source, used for both the type and the runtime assignment) so spreads compile and work regardless of what `absoluteFill` resolves to on a given platform. `absoluteFill` itself is left untouched.

```ts
const absoluteFillObject = {
    position: 'absolute',
    left: 0, right: 0, top: 0, bottom: 0,
} as const
```

Closes #1200

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility for styles that use `absoluteFillObject`.
  * Ensured absolute-fill style values consistently expose explicit positioning properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->